### PR TITLE
Fix ambiguous model catalog metadata selection

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@ Adds an Advanced Model Configuration page to the [DeepSeek Harness](https://gith
 - Configure provider-level custom request headers for model requests.
 - Supports `openai-completions`, `openai-responses`, and `anthropic-messages`.
 - Fetch candidate models through a unified `GET /models` flow, with select all, invert selection, and select none actions.
-- Completes missing context windows, maximum output, input modalities, and reasoning capabilities from `models.dev`.
+- Completes missing context windows, maximum output, input modalities, and reasoning capabilities from `models.dev`; it first selects the official provider implied by the model ID, then falls back to the default provider record, with whole-record switching available before saving.
 - Edit each selected model's capacity, text/image input support, and `reasoningEfforts`; review a configuration preview before saving.
 - Chinese and English UI copy follows the Harness language setting.
 - API keys are written only through Harness credential storage, never to `settings.yaml` or the configuration preview.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - 支持在 provider 层配置自定义请求 Header，并应用于模型请求。
 - 支持 `openai-completions`、`openai-responses`、`anthropic-messages`。
 - 通过统一的 `GET /models` 流程获取候选模型，支持全选、反选和全不选。
-- 从 `models.dev` 补全缺失的上下文窗口、最大输出、输入模态和推理能力。
+- 从 `models.dev` 补全缺失的上下文窗口、最大输出、输入模态和推理能力；优先按模型名称选择官方 provider，找不到时选择默认 provider，并可在保存前切换完整 provider 记录。
 - 在保存前编辑每个模型的容量、文本/图片输入和 `reasoningEfforts`，并查看不含密钥的配置预览。
 - 所有界面文案支持中文和英文，跟随 Harness 语言设置。
 - API Key 仅经 Harness 凭据存储写入，不会进入 `settings.yaml` 或配置预览。

--- a/docs/model-config-plugin-design.md
+++ b/docs/model-config-plugin-design.md
@@ -113,7 +113,16 @@ models:
 
 ### 4.4 发现结果的每模型参数回填
 
-`llm.discoverModels` 只披露 `id`/`name`/`contextWindow`/`maxTokens`，**不披露推理能力**。采纳发现结果后，推理强度由用户手工声明（picker 中每个待采纳模型默认不预填 effort）。这是 G1 的边界：发现是"候选"，参数是"声明"。
+`llm.discoverModels` 只披露 `id`/`name`/`contextWindow`/`maxTokens`，**不披露推理能力**。picker 另从匹配到的 `models.dev` 记录读取推理信息：`reasoning: false` 写为 `reasoningEfforts: false`，可识别的 effort 选项写为 `reasoningEfforts` dict，没有推理信息时保持字段省略。用户可手动添加或编辑 effort；不提供“继承/禁用/声明”模式下拉框。这是 G1 的边界：发现是"候选"，参数是"声明"。
+
+### 4.5 models.dev 目录匹配
+
+目录补全只在发现候选进入 picker 时执行，且一个目录记录是不可拆分的 provider 选择。匹配顺序固定为两层：
+
+1. **模型名称识别官方 provider**：从模型 ID 的规范名称或 provider 前缀识别官方 provider；例如 `deepseek-*` → `deepseek`、`gpt-*`/`o1*`/`o3*`/`o4*` → `openai`、`grok-*`/`x-ai/grok-*`/`xai/grok-*`/`grok/grok-*` → `xai`、`claude-*` → `anthropic`、`gemini-*` → `google`。只有该 provider 存在同 ID 或去掉已知 provider 前缀后的目录 ID 时才采用；这一步只选择元数据来源，不改写发给端点的模型 ID。
+2. **默认 provider 选择**：官方 provider 没有对应目录记录时，在所有精确 ID 候选中按完整记录排序，先比较 `contextWindow` 升序，再比较 `maxTokens` 升序，最后按 provider ID 稳定排序，选择一条完整记录。缺失容量排在有容量的记录之后；不把不同 provider 的字段合成一条记录。
+
+模型 ID 没有目录记录时不做模糊匹配，保持发现结果可编辑。用户可在 picker 中选择其他完整 provider 记录；切换来源会整体替换该模型的目录字段，手工改过的字段保持用户值。endpoint hostname 与 API 协议不再覆盖模型名称识别结果，因为聚合代理的 hostname 和协议通常不能证明真实上游 provider。
 
 ## 5. 端到端流程设计
 
@@ -131,6 +140,8 @@ models:
 
 "拉取模型"针对**表单当前值**发起 `llm.discoverModels`（含未保存的 baseURL、未存储的键），回复进 picker（候选，不直接写入）；已配置候选默认不选中，采纳不覆盖用户调优过的容量。拉取失败（`DISCOVERY_FAILED`/`NO_DISCOVERY`/`DISCOVERY_UNSUPPORTED`/`INVALID_CREDENTIAL`）在行内显示 adapter 的消息，模型行保持手编可编辑。
 
+发现候选的 `models.dev` 回填遵循 4.5 的两层匹配：模型名称命中官方 provider 时采用该 provider 的完整记录，否则采用默认的完整 provider 记录。picker 必须显示多候选的 provider 来源，且来源切换是记录级替换，不允许从不同 provider 分别取上下文、输出、输入或 reasoning 字段。
+
 ### 5.4 每模型参数编辑（G1，新增）
 
 `ModelListEditor` 每行 disclosure 在既有上下文/输出字段之上增加推理强度区：
@@ -139,10 +150,10 @@ models:
 |---|---|---|
 | 上下文大小 | 计数输入（`K`/`M` 后缀，存纯计数） | draft 内编辑，随整组 `models` 数组一次落盘 |
 | 最大输出长度 | 同上 | 同上 |
-| 推理强度 | 三态开关（继承/禁用/声明）+ 级别行列表：级别名 + wire 拼写输入 | 同上 |
+| 推理强度 | models.dev 回填的级别行列表；未声明时可通过“添加级别”控件创建；级别名 + wire 拼写输入 | 同上 |
 
 - **落盘形态与既有编辑器一致**：持 draft 数组，一次 `settings.mutate` 写整组 `models`（或重置时 unset 该数组）——逐索引 path op 在数组位移时脆弱，不使用。
-- 推理强度三态：省略（继承 catalog 能力）/ `false`（非推理模型）/ 声明 dict。声明 dict 时只渲染**已声明**级别 + 一个"添加级别"入口，级别候选读自命名空间 schema 的 dict 键约束（见 4.3），排除已声明者；省略某级别即"不支持"，不做隐式默认。
+- 推理强度由目录记录或用户声明决定：目录明确非推理时写 `false`，目录提供 effort 时写声明 dict，目录没有推理信息时保持省略。省略或 `false` 时仍渲染“添加级别”控件，用户选择一个级别后才创建声明 dict；声明 dict 时渲染**已声明**级别、同一“添加级别”入口和清除覆盖按钮。级别候选读自命名空间 schema 的 dict 键约束（见 4.3），排除已声明者；省略某级别即"不支持"，不做隐式默认。
 - `off` 三态 UI：不声明（无行）/ 空值行（`off:`，按方言映射）/ 带值行。清空非 `off` 级别的拼写 = 删除该级别行（unset），不写空串——空串与空 dict 都是被拒绝的非法值。
 - 校验在 draft 上先行（重复 id、非法级别、`off` 之外空值、非正整数容量），写入前再经 schema；行内报错。
 - 继承视图：`base` 层的 models 数组在用户层未覆盖时以继承态显示；首次编辑把完整数组物化进用户层；重置 = unset 该数组。
@@ -166,7 +177,8 @@ models:
 | D3 | 每模型推理强度落在 `reasoningEfforts`（pi-ai 语义）；deepseek 按需扩展单字段 | 级别是 opaque id、wire 拼写适配器拥有；off 三态不可用空值消除 | [pi-ai catalog 语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#catalog-resolution) |
 | D4 | 树内形态演进 `ui-settings-models`；独立插件形态注册自己的 section，互斥由 profile 层禁用 `ui-settings-models` 行实现 | 双模型页互相漂移；槽位是唯一组合通道 | [ui-settings README](../deepseek-harness/packages/client/ui-settings/README.md) |
 | D5 | UI 手写卡片而非 schema 通用渲染器 | 通用渲染器已被实现并否决：无层次、不可用 | [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) |
-| D6 | 发现结果不自动回填推理强度 | 发现只披露 id/容量，回填即猜测；声明是用户决定 | [pi-ai 发现语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#endpoint-interrogation) |
+| D6 | 推理能力仅从匹配目录记录回填，缺失时保持省略 | 发现端点本身不披露 effort；无目录事实时不猜测，用户可手工声明 | [pi-ai 发现语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#endpoint-interrogation) |
+| D7 | 目录歧义按官方 provider 优先、整条默认记录回退 | 聚合代理不能由 hostname 证明上游；跨 provider 拼字段会制造不存在的能力组合 | 本文 4.5 |
 
 ## 7. 错误处理与安全
 
@@ -191,15 +203,16 @@ models:
 ## 10. 验证方案
 
 - **单元**：schema 校验（重复 id、`reasoningEfforts` 非法形态、off 三态）、解析拒绝、draft → path op 生成、容量 `K/M` 解析与最短回写、凭据派生与 ownership 判定。
+- **目录匹配**：官方模型名命中 provider、带 provider 前缀的别名归一化、官方记录缺失时整条记录的最小排序、切换 provider 不跨记录拼字段、未知 ID 保持手工编辑。
 - **REAL-composition**：boot 测试专用 cordis.yml 经 Loader 与 app/process 装载，断言"写 profile → 路由注册 → `llm.providers` 目录生效 → 下一次请求使用新配置"。
-- **组件（jsdom）**：ProviderCard 门控、拉取携带表单当前值、picker 采纳不覆盖调优行、每模型 effort 编辑与 unset、冲突重试、只读姿态。
+- **组件（jsdom）**：ProviderCard 门控、拉取携带表单当前值、picker 采纳不覆盖调优行、目录推理回填、手动添加或清除每模型 effort、冲突重试、只读姿态。
 - **e2e 快照（keyless）**：仿照 `apps/web/tests/models-settings.e2e.ts` 钉死"新增自定义端点 → 拉取 → 配置每模型参数 → 设置页渲染"全链路，scaffold `harnessHome`。
 - **覆盖门**：client 包进每文件 100% 覆盖门；`test:gui` + `DSH_SNAPSHOT=replay test:web`。
 
 ## 11. 已知限制与后续
 
 - 拉取仅覆盖 OpenAI-compatible `GET /models`；其他协议手编。
-- 每模型 effort 仅对已声明级别可编辑；catalog 继承级别不可见（省略 = 沿用 catalog，无法在 UI 中"取消声明"）。
+- 目录没有 effort 信息时 UI 不猜测能力；用户手动声明后只提供其已添加的级别。
 - 独立插件形态与 `ui-settings-models` 互斥（D4）：共存时双页面由同一命名空间驱动，修改相互可见但 UX 重复。
 - schema-generic 的"高级参数"（retryPolicy、超时等）延续既有姿态：留在 `settings.yaml`。
 

--- a/src/client.js
+++ b/src/client.js
@@ -28,14 +28,12 @@ window.__ModuleLoader__.load({
       restored: 'Restored the inherited model list.',
       addEndpoint: 'Add endpoint',
       reasoning: 'Reasoning effort',
-      inheritCatalog: 'Inherit the model catalog',
-      disableReasoning: 'Disable reasoning',
-      declareEfforts: 'Declare supported efforts',
       offPlaceholder: 'Blank disables per protocol',
       wirePlaceholder: 'Wire spelling',
       wireLabel: '{level} wire spelling',
       delete: 'Delete',
       addLevel: 'Add effort',
+      clearReasoning: 'Clear reasoning override',
       add: 'Add',
       modelIndex: 'Model {index}',
       modelId: 'Model ID',
@@ -67,7 +65,7 @@ window.__ModuleLoader__.load({
       endpointKey: 'API key',
       endpointKeyPlaceholder: 'Used only to fetch models and store the credential',
       endpointNameRequired: 'Enter an endpoint name.',
-      endpointNameInvalid: 'The name may contain only English letters.',
+      endpointNameInvalid: 'The name must start with an English letter and contain only English letters and numbers.',
       endpointUrlRequired: 'Enter an endpoint URL.',
       endpointUrlInvalid: 'Enter a valid http:// or https:// URL.',
       endpointUrlProtocol: 'The URL must start with http:// or https://.',
@@ -88,8 +86,13 @@ window.__ModuleLoader__.load({
       cancel: 'Cancel',
       confirmSave: 'Confirm and save',
       retryKey: 'Retry saving API key',
-      catalogApplied: 'Completed missing model metadata from models.dev.',
+      catalogApplied: 'Completed metadata for {matched} models. Official providers: {official}; default providers: {ambiguous}; no catalog match: {unmatched}.',
       catalogUnavailable: 'Could not load models.dev metadata. The endpoint results remain editable.',
+      catalogSource: 'Catalog source',
+      catalogSourceDescription: 'Each option is one provider record. Switching it replaces all catalog-derived fields for this model.',
+      catalogDefault: 'Default provider: {provider} ({context}/{output})',
+      catalogOfficial: 'Official provider: {provider} ({context}/{output})',
+      catalogProvider: '{provider} ({context}/{output})',
       reasoningInvalid: 'Reasoning efforts must inherit, be disabled, or be an effort list.',
       reasoningEmpty: 'A declared reasoning list needs at least one effort.',
       reasoningOffOnly: 'A list with only off has no usable reasoning effort.',
@@ -120,14 +123,12 @@ window.__ModuleLoader__.load({
       restored: '已恢复继承的模型列表。',
       addEndpoint: '新增端点',
       reasoning: '推理强度',
-      inheritCatalog: '继承模型目录',
-      disableReasoning: '禁用推理',
-      declareEfforts: '声明支持的级别',
       offPlaceholder: '留空表示按协议关闭',
       wirePlaceholder: '服务端拼写',
       wireLabel: '{level} 服务端拼写',
       delete: '删除',
       addLevel: '添加级别',
+      clearReasoning: '清除推理覆盖',
       add: '添加',
       modelIndex: '模型 {index}',
       modelId: '模型 ID',
@@ -159,7 +160,7 @@ window.__ModuleLoader__.load({
       endpointKey: 'API Key',
       endpointKeyPlaceholder: '仅用于获取模型和保存凭据',
       endpointNameRequired: '请填写端点名称。',
-      endpointNameInvalid: '名称只能包含英文大小写字母。',
+      endpointNameInvalid: '名称必须以英文字母开头，只能包含英文字母和数字。',
       endpointUrlRequired: '请填写端点 URL。',
       endpointUrlInvalid: '请输入有效的 http:// 或 https:// URL。',
       endpointUrlProtocol: 'URL 必须以 http:// 或 https:// 开头。',
@@ -180,8 +181,13 @@ window.__ModuleLoader__.load({
       cancel: '取消',
       confirmSave: '确认并保存',
       retryKey: '重试保存 API Key',
-      catalogApplied: '已从 models.dev 补全缺失的模型参数。',
+      catalogApplied: '已为 {matched} 个模型补全参数；官方 provider {official} 个，默认 provider {ambiguous} 个，没有目录记录 {unmatched} 个。',
       catalogUnavailable: '无法加载 models.dev 元数据；端点返回的模型仍可编辑。',
+      catalogSource: '目录来源',
+      catalogSourceDescription: '每个选项都是一个完整的 provider 记录；切换后会整体替换该模型的目录参数。',
+      catalogDefault: '默认 provider：{provider}（{context}/{output}）',
+      catalogOfficial: '官方 provider：{provider}（{context}/{output}）',
+      catalogProvider: '{provider}（{context}/{output}）',
       reasoningInvalid: '推理强度必须是“继承”、禁用或级别列表。',
       reasoningEmpty: '已声明推理强度时至少选择一个级别。',
       reasoningOffOnly: '仅声明关闭级别没有可用的推理强度。',
@@ -232,44 +238,135 @@ window.__ModuleLoader__.load({
     function modelRecordCandidates(catalog, id) {
       if (catalog === null || typeof catalog !== 'object') return []
       const matches = []
-      for (const provider of Object.values(catalog)) {
+      for (const [providerKey, provider] of Object.entries(catalog)) {
         if (provider === null || typeof provider !== 'object') continue
         const models = provider.models
         const model = models !== null && typeof models === 'object' ? models[id] : undefined
-        if (model !== null && typeof model === 'object') matches.push({ provider, model })
+        if (model !== null && typeof model === 'object') {
+          matches.push({
+            providerId: typeof provider.id === 'string' && provider.id !== '' ? provider.id : providerKey,
+            model,
+          })
+        }
       }
       return matches
     }
 
-    function modelMetadataFingerprint(model) {
-      const limit = model.limit !== null && typeof model.limit === 'object' ? model.limit : {}
-      const modalities = model.modalities !== null && typeof model.modalities === 'object' ? model.modalities : {}
-      return JSON.stringify({
-        context: positiveCatalogLimit(limit.context),
-        output: positiveCatalogLimit(limit.output),
-        input: Array.isArray(modalities.input) ? modalities.input.filter(value => value === 'text' || value === 'image') : [],
-        reasoning: model.reasoning === false ? false : model.reasoning_options,
-      })
+    const OFFICIAL_PROVIDER_RULES = [
+      ['deepseek', /^deepseek(?:[-/.]|$)/],
+      ['openai', /^(?:gpt(?:[-/.]|$)|o[134](?:[-/.]|$)|codex(?:[-/.]|$))/],
+      ['xai', /^(?:grok|x-ai\/grok|xai\/grok)(?:[-/.]|$)/],
+      ['anthropic', /^claude(?:[-/.]|$)/],
+      ['google', /^gemini(?:[-/.]|$)/],
+      ['mistral', /^mistral(?:[-/.]|$)/],
+      ['cohere', /^command(?:[-/.]|$)/],
+      ['nvidia', /^nemotron(?:[-/.]|$)/],
+      ['meta', /^llama(?:[-/.]|$)/],
+      ['xiaomi', /^mimo(?:[-/.]|$)/],
+      ['alibaba', /^qwen(?:[-/.]|$)/],
+    ]
+
+    function officialCatalogProviderForModel(id) {
+      const normalized = id.toLowerCase()
+      const bare = normalized.includes('/') ? normalized.slice(normalized.lastIndexOf('/') + 1) : normalized
+      return OFFICIAL_PROVIDER_RULES.find(([, rule]) => rule.test(normalized) || rule.test(bare))?.[0]
     }
 
-    function catalogModelForEndpoint(catalog, id, baseURL, api) {
-      const candidates = modelRecordCandidates(catalog, id)
-      if (candidates.length === 0) return undefined
-      let hostname = ''
-      try { hostname = new URL(baseURL).hostname.toLowerCase() } catch {}
-      const hostMatch = candidates.find(({ provider }) => typeof provider.id === 'string' && hostname.includes(provider.id.toLowerCase()))
-      if (hostMatch !== undefined) return hostMatch.model
-      const canonicalProvider = api === 'openai-responses'
-        ? 'openai'
-        : api === 'anthropic-messages'
-          ? 'anthropic'
-          : undefined
-      if (canonicalProvider !== undefined) {
-        const canonical = candidates.find(({ provider }) => provider.id === canonicalProvider)
-        if (canonical !== undefined) return canonical.model
+    function catalogModelIdVariants(id) {
+      const variants = [id]
+      if (id.includes('/')) variants.push(id.slice(id.lastIndexOf('/') + 1))
+      return [...new Set(variants)]
+    }
+
+    function catalogProviderModel(catalog, providerId, id) {
+      if (catalog === null || typeof catalog !== 'object') return undefined
+      for (const [providerKey, provider] of Object.entries(catalog)) {
+        if (provider === null || typeof provider !== 'object') continue
+        const currentProviderId = typeof provider.id === 'string' && provider.id !== '' ? provider.id : providerKey
+        if (currentProviderId !== providerId) continue
+        const models = provider.models
+        if (models === null || typeof models !== 'object') return undefined
+        for (const variant of catalogModelIdVariants(id)) {
+          const key = Object.keys(models).find(modelId => modelId === variant || modelId.toLowerCase() === variant.toLowerCase())
+          const model = key === undefined ? undefined : models[key]
+          if (model !== null && typeof model === 'object') return { providerId, modelId: key, model }
+        }
+        return undefined
       }
-      const fingerprints = new Set(candidates.map(({ model }) => modelMetadataFingerprint(model)))
-      return fingerprints.size === 1 ? candidates[0].model : undefined
+      return undefined
+    }
+
+    function catalogLimit(model, field) {
+      const limit = model !== null && typeof model === 'object'
+        && model.limit !== null && typeof model.limit === 'object' ? model.limit : {}
+      return positiveCatalogLimit(limit[field])
+    }
+
+    function catalogLimitText(model, field) {
+      const value = catalogLimit(model, field)
+      return value === undefined ? '?' : String(value)
+    }
+
+    function compareCatalogLimits(left, right, field) {
+      const leftValue = catalogLimit(left, field)
+      const rightValue = catalogLimit(right, field)
+      if (leftValue === undefined && rightValue === undefined) return 0
+      if (leftValue === undefined) return 1
+      if (rightValue === undefined) return -1
+      return leftValue - rightValue
+    }
+
+    function providerSelection(providerId) {
+      return `provider:${providerId}`
+    }
+
+    // Rank complete provider records; never combine fields from different providers.
+    function defaultCatalogCandidate(candidates) {
+      return [...candidates].sort((left, right) => {
+        const context = compareCatalogLimits(left.model, right.model, 'context')
+        if (context !== 0) return context
+        const output = compareCatalogLimits(left.model, right.model, 'output')
+        if (output !== 0) return output
+        return left.providerId.localeCompare(right.providerId)
+      })[0]
+    }
+
+    function catalogMatchForEndpoint(catalog, id) {
+      const exactCandidates = modelRecordCandidates(catalog, id)
+      const officialProvider = officialCatalogProviderForModel(id)
+      const official = officialProvider === undefined ? undefined : catalogProviderModel(catalog, officialProvider, id)
+      const exactOfficial = officialProvider === undefined
+        ? undefined
+        : exactCandidates.find(candidate => candidate.providerId === officialProvider)
+      const officialCandidate = exactOfficial ?? official
+      const candidates = official !== undefined && exactOfficial === undefined
+        ? [...exactCandidates, official]
+        : exactCandidates
+      if (officialCandidate !== undefined) {
+        return {
+          candidates,
+          selection: providerSelection(officialCandidate.providerId),
+          reason: 'official',
+          officialProvider,
+        }
+      }
+      if (candidates.length === 0) return { candidates, selection: undefined, reason: 'none' }
+      if (candidates.length === 1) {
+        return { candidates, selection: providerSelection(candidates[0].providerId), reason: 'unique' }
+      }
+      const defaultCandidate = defaultCatalogCandidate(candidates)
+      return {
+        candidates,
+        selection: defaultCandidate === undefined ? undefined : providerSelection(defaultCandidate.providerId),
+        reason: 'default',
+      }
+    }
+
+    function catalogRecordForSelection(match, selection) {
+      if (match === undefined) return undefined
+      const selected = selection === undefined ? match.selection : selection
+      const candidate = match.candidates.find(item => providerSelection(item.providerId) === selected)
+      return candidate === undefined ? match.candidates[0]?.model : candidate.model
     }
 
     function reasoningEffortsFromCatalog(model) {
@@ -285,8 +382,8 @@ window.__ModuleLoader__.load({
       return Object.keys(result).some(level => level !== 'off') ? result : undefined
     }
 
-    function enrichDiscoveredModel(candidate, catalog, baseURL, api) {
-      const record = catalogModelForEndpoint(catalog, candidate.id, baseURL, api)
+    function enrichDiscoveredModel(candidate, match, selection) {
+      const record = catalogRecordForSelection(match, selection)
       if (record === undefined) return { ...candidate }
       const limit = record.limit !== null && typeof record.limit === 'object' ? record.limit : {}
       const modalities = record.modalities !== null && typeof record.modalities === 'object' ? record.modalities : {}
@@ -485,14 +582,9 @@ window.__ModuleLoader__.load({
 
     function ReasoningEditor({ value, onChange, disabled, t }) {
       const [newLevel, setNewLevel] = useState('')
-      const mode = value === undefined ? 'inherit' : value === false ? 'disabled' : 'declared'
-      const efforts = mode === 'declared' ? value : {}
+      const declaredMode = value !== null && typeof value === 'object' && !Array.isArray(value)
+      const efforts = declaredMode ? value : {}
       const declared = Object.keys(efforts)
-      const changeMode = (next) => {
-        if (next === 'inherit') onChange(undefined)
-        else if (next === 'disabled') onChange(false)
-        else onChange({ low: 'low' })
-      }
       const changeWire = (level, wire) => {
         const next = { ...efforts }
         if (level === 'off') next.off = wire === '' ? null : wire
@@ -505,16 +597,9 @@ window.__ModuleLoader__.load({
         onChange({ ...efforts, [newLevel]: newLevel === 'off' ? null : newLevel })
         setNewLevel('')
       }
-      return h('div', { style: { display: 'flex', flexDirection: 'column', gap: '8px', paddingTop: '8px' } },
-        h(Field, { label: t('reasoning') }, h('select', {
-          style: inputStyle, value: mode, disabled, onChange: event => changeMode(event.target.value),
-        },
-        h('option', { value: 'inherit' }, t('inheritCatalog')),
-        h('option', { value: 'disabled' }, t('disableReasoning')),
-        h('option', { value: 'declared' }, t('declareEfforts')),
-        )),
-        mode === 'declared' ? h('div', { style: { display: 'flex', flexDirection: 'column', gap: '6px' } },
-          declared.map(level => h('div', { key: level, style: { display: 'grid', gridTemplateColumns: '90px minmax(0, 1fr) auto', gap: '6px', alignItems: 'center' } },
+      return h('div', { style: { display: 'flex', flexDirection: 'column', gap: '6px', paddingTop: '8px' } },
+        h('span', { style: { fontSize: '12px', color: 'var(--dsw-alias-label-secondary)' } }, t('reasoning')),
+        declaredMode ? declared.map(level => h('div', { key: level, style: { display: 'grid', gridTemplateColumns: '90px minmax(0, 1fr) auto', gap: '6px', alignItems: 'center' } },
             h('span', { style: { fontSize: '13px' } }, level),
             h('input', {
               style: inputStyle,
@@ -532,19 +617,24 @@ window.__ModuleLoader__.load({
                 onChange(next)
               },
             }, t('delete')),
-          )),
-          declared.length < EFFORTS.length ? h('div', { style: { display: 'flex', gap: '6px' } },
-            h('select', { style: inputStyle, value: newLevel, disabled, onChange: event => setNewLevel(event.target.value) },
-              h('option', { value: '' }, t('addLevel')),
-              EFFORTS.filter(level => !declared.includes(level)).map(level => h('option', { key: level, value: level }, level)),
-            ),
-            h('button', { type: 'button', style: buttonStyle, disabled: disabled || newLevel === '', onClick: add }, t('add')),
-          ) : null,
+          )) : null,
+        declared.length < EFFORTS.length ? h('div', { style: { display: 'flex', gap: '6px' } },
+          h('select', { style: inputStyle, value: newLevel, disabled, onChange: event => setNewLevel(event.target.value) },
+            h('option', { value: '' }, t('addLevel')),
+            EFFORTS.filter(level => !declared.includes(level)).map(level => h('option', { key: level, value: level }, level)),
+          ),
+          h('button', { type: 'button', style: buttonStyle, disabled: disabled || newLevel === '', onClick: add }, t('add')),
+        ) : null,
+        declaredMode ? h('div', { style: { display: 'flex', justifyContent: 'flex-end' } },
+          h('button', { type: 'button', style: buttonStyle, disabled, onClick: () => onChange(undefined) }, t('clearReasoning')),
         ) : null,
       )
     }
 
-    function ModelRow({ model, index, onChange, disabled, lockId = false, t }) {
+    function ModelRow({
+      model, index, onChange, disabled, lockId = false,
+      catalogChoice, catalogCandidates = [], catalogDefaultProvider, catalogOfficialProvider, onCatalogChoice, t,
+    }) {
       const patch = changes => {
         const next = { ...model, ...changes }
         for (const [key, value] of Object.entries(next)) if (value === undefined) delete next[key]
@@ -559,6 +649,34 @@ window.__ModuleLoader__.load({
       }
       return h('details', { style: { border: '1px solid var(--dsw-alias-border-l2)', borderRadius: '8px', padding: '8px' } },
         h('summary', { style: { cursor: 'pointer', fontSize: '14px' } }, typeof model.id === 'string' && model.id !== '' ? model.id : t('modelIndex', { index: index + 1 })),
+        catalogCandidates.length > 1 ? h('div', { style: { display: 'flex', flexDirection: 'column', gap: '5px', paddingTop: '10px' } },
+          h(Field, { label: t('catalogSource') }, h('select', {
+            style: inputStyle,
+            value: catalogChoice ?? '',
+            disabled,
+            onChange: event => onCatalogChoice?.(event.target.value),
+          }, catalogCandidates.map(candidate => h('option', {
+            key: candidate.providerId,
+            value: providerSelection(candidate.providerId),
+          }, candidate.providerId === catalogDefaultProvider
+            ? t('catalogDefault', {
+              provider: candidate.providerId,
+              context: catalogLimitText(candidate.model, 'context'),
+              output: catalogLimitText(candidate.model, 'output'),
+            })
+            : candidate.providerId === catalogOfficialProvider
+              ? t('catalogOfficial', {
+                provider: candidate.providerId,
+                context: catalogLimitText(candidate.model, 'context'),
+                output: catalogLimitText(candidate.model, 'output'),
+              })
+            : t('catalogProvider', {
+              provider: candidate.providerId,
+              context: catalogLimitText(candidate.model, 'context'),
+              output: catalogLimitText(candidate.model, 'output'),
+            }))))),
+          h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, t('catalogSourceDescription')),
+        ) : null,
         h('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '10px', paddingTop: '10px' } },
           h(Field, { label: t('modelId') }, h('input', {
             style: inputStyle, value: typeof model.id === 'string' ? model.id : '', disabled: disabled || lockId,
@@ -600,6 +718,8 @@ window.__ModuleLoader__.load({
       const [candidates, setCandidates] = useState(undefined)
       const [selected, setSelected] = useState(new Set())
       const [modelDrafts, setModelDrafts] = useState({})
+      const [catalogMatches, setCatalogMatches] = useState({})
+      const [catalogSelections, setCatalogSelections] = useState({})
       const [busy, setBusy] = useState(false)
       const [failure, setFailure] = useState(undefined)
       const [catalogNotice, setCatalogNotice] = useState(undefined)
@@ -608,7 +728,7 @@ window.__ModuleLoader__.load({
       const keyRef = route === '' ? '' : `${route.toUpperCase()}_API_KEY`
       const nameError = endpoint.name.length === 0
         ? t('endpointNameRequired')
-        : /^[A-Za-z]+$/.test(endpoint.name) ? undefined : t('endpointNameInvalid')
+        : /^[A-Za-z][A-Za-z0-9]*$/.test(endpoint.name) ? undefined : t('endpointNameInvalid')
       const urlError = endpoint.baseURL.length === 0 ? t('endpointUrlRequired') : endpointUrlError(endpoint.baseURL, t)
       const keyError = apiKeyError(endpoint.apiKey, t)
       const requestHeadersError = headersError(endpoint.headers, t)
@@ -635,6 +755,8 @@ window.__ModuleLoader__.load({
         setCandidates(undefined)
         setSelected(new Set())
         setModelDrafts({})
+        setCatalogMatches({})
+        setCatalogSelections({})
         setFailure(undefined)
         setCatalogNotice(undefined)
       }
@@ -663,13 +785,37 @@ window.__ModuleLoader__.load({
             setFailure(t('discoveryEmpty'))
             return
           }
-          const enriched = catalog === undefined
-            ? models
-            : models.map(model => enrichDiscoveredModel(model, catalog, endpoint.baseURL.trim(), endpoint.api))
+          const prepared = catalog === undefined
+            ? models.map(candidate => ({ candidate, match: undefined }))
+            : models.map(candidate => {
+              const match = {
+                ...catalogMatchForEndpoint(catalog, candidate.id),
+                candidate,
+              }
+              return {
+                candidate: enrichDiscoveredModel(candidate, match, match.selection),
+                match,
+              }
+            })
+          const enriched = prepared.map(item => item.candidate)
           setCandidates(enriched)
           setSelected(new Set(enriched.map(model => model.id)))
           setModelDrafts(Object.fromEntries(enriched.map(model => [model.id, { ...model }])))
-          setCatalogNotice(t(catalog === undefined ? 'catalogUnavailable' : 'catalogApplied'))
+          setCatalogMatches(Object.fromEntries(prepared
+            .filter(item => item.match !== undefined)
+            .map(item => [item.candidate.id, item.match])))
+          setCatalogSelections(Object.fromEntries(prepared
+            .filter(item => item.match !== undefined)
+            .map(item => [item.candidate.id, item.match.selection])))
+          if (catalog === undefined) {
+            setCatalogNotice(t('catalogUnavailable'))
+          } else {
+            const matched = prepared.filter(item => item.match.reason !== 'none').length
+            const official = prepared.filter(item => item.match.reason === 'official').length
+            const ambiguous = prepared.filter(item => item.match.reason === 'default').length
+            const unmatched = prepared.length - matched
+            setCatalogNotice(t('catalogApplied', { matched, official, ambiguous, unmatched }))
+          }
         } catch (error) {
           setFailure(messageOf(error))
         } finally {
@@ -688,6 +834,22 @@ window.__ModuleLoader__.load({
         .filter(model => !current.has(model.id))
         .map(model => model.id)))
       const updateSelectedModel = (id, next) => setModelDrafts(current => ({ ...current, [id]: next }))
+      const chooseCatalogSelection = (id, selection) => {
+        const match = catalogMatches[id]
+        if (match === undefined || match.candidate === undefined) return
+        const previousSelection = catalogSelections[id] ?? match.selection
+        const previous = enrichDiscoveredModel(match.candidate, match, previousSelection)
+        const nextModel = enrichDiscoveredModel(match.candidate, match, selection)
+        const current = modelDrafts[id] ?? previous
+        const next = { ...current }
+        for (const field of ['name', 'contextWindow', 'maxTokens', 'input', 'reasoningEfforts']) {
+          if (!jsonEqual(current[field], previous[field])) continue
+          if (nextModel[field] === undefined) delete next[field]
+          else next[field] = nextModel[field]
+        }
+        setCatalogSelections(currentSelections => ({ ...currentSelections, [id]: selection }))
+        setModelDrafts(currentDrafts => ({ ...currentDrafts, [id]: next }))
+      }
       const save = async () => {
         setBusy(true)
         setFailure(undefined)
@@ -773,15 +935,27 @@ window.__ModuleLoader__.load({
           ))),
           selectedModels.length === 0 ? null : h('div', { style: { display: 'flex', flexDirection: 'column', gap: '8px' } },
             h('strong', { style: { fontSize: '13px' } }, t('selectedModelParameters')),
-            selectedModels.map((model, index) => h(ModelRow, {
-              key: model.id,
-              model,
-              index,
-              onChange: next => updateSelectedModel(model.id, next),
-              disabled: busy || profileCreated,
-              lockId: true,
-              t,
-            })),
+            selectedModels.map((model, index) => {
+              const match = catalogMatches[model.id]
+              const defaultProvider = match?.reason === 'default'
+                ? match.candidates.find(candidate => providerSelection(candidate.providerId) === match.selection)?.providerId
+                : undefined
+              const officialProvider = match?.reason === 'official' ? match.officialProvider : undefined
+              return h(ModelRow, {
+                key: model.id,
+                model,
+                index,
+                onChange: next => updateSelectedModel(model.id, next),
+                disabled: busy || profileCreated,
+                lockId: true,
+                catalogChoice: catalogSelections[model.id] ?? match?.selection,
+                catalogCandidates: match?.candidates,
+                catalogDefaultProvider: defaultProvider,
+                catalogOfficialProvider: officialProvider,
+                onCatalogChoice: next => chooseCatalogSelection(model.id, next),
+                t,
+              })
+            }),
           ),
         ),
         selectedModels.length === 0 ? null : h('div', { style: { display: 'flex', flexDirection: 'column', gap: '6px' } },


### PR DESCRIPTION
Fixes #2

## Problem

`models.dev` can contain multiple metadata records for the same model ID. The previous exact-match logic left many Grok and proxied DeepSeek models without context, output, input, or reasoning metadata when their records differed.

## Changes

- Recognize common official providers from model IDs before fallback selection: DeepSeek, OpenAI/Codex, xAI Grok, Anthropic Claude, Google Gemini, Mistral, Cohere, NVIDIA Nemotron, Meta Llama, Xiaomi MiMo, and Qwen.
- Normalize provider-prefixed model IDs such as `x-ai/grok-4.5`, `xai/grok-4.6`, and `grok/grok-4.3` to select the corresponding official provider record without changing the model ID sent to the endpoint.
- When no official record exists, select one complete default provider record by ascending context window, then maximum output, then provider ID. Fields are never assembled from different provider records.
- Show the selected catalog source in the new-endpoint picker and let users switch the entire provider record before saving. User-edited fields remain untouched when the source changes.
- Populate reasoning only when `models.dev` provides it. Missing reasoning metadata remains omitted; the existing Add effort control can create a manual declaration, and declared overrides can be cleared.
- Remove the reasoning mode dropdown and allow endpoint names to include digits after an initial English letter.
- Document the selection order, inference rules, UI behavior, and validation coverage in Chinese and English documentation.

## Scope

- Applies to model discovery while creating a new endpoint.
- Does not re-enrich existing provider configurations.
- Does not use hostname or API protocol as a separate catalog-selection rule.

## Validation

- `node --check src/client.js`
- `git diff --check`
- In-memory behavior checks for official-provider selection, default-provider fallback, and omitted/false/declared reasoning states.