### PR TITLE
Unify endpoint editing and model refresh

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,7 @@ Adds an Advanced Model Configuration page to the [DeepSeek Harness](https://gith
 - Configure provider-level custom request headers for model requests.
 - Supports `openai-completions`, `openai-responses`, and `anthropic-messages`.
 - Fetch candidate models through a unified `GET /models` flow, with select all, invert selection, and select none actions.
+- Use the same editor for new and saved endpoints; saved endpoints can refresh models, new models start unchecked, and checked models remain selected after a refresh.
 - Completes missing context windows, maximum output, input modalities, and reasoning capabilities from `models.dev`; it first selects the official provider implied by the model ID, then falls back to the default provider record, with whole-record switching available before saving.
 - Edit each selected model's capacity, text/image input support, and `reasoningEfforts`; review a configuration preview before saving.
 - Chinese and English UI copy follows the Harness language setting.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 支持在 provider 层配置自定义请求 Header，并应用于模型请求。
 - 支持 `openai-completions`、`openai-responses`、`anthropic-messages`。
 - 通过统一的 `GET /models` 流程获取候选模型，支持全选、反选和全不选。
+- 新增端点和已保存端点共用编辑器；已保存端点可重新拉取模型，新增模型默认不勾选，已有勾选模型在刷新后保留。
 - 从 `models.dev` 补全缺失的上下文窗口、最大输出、输入模态和推理能力；优先按模型名称选择官方 provider，找不到时选择默认 provider，并可在保存前切换完整 provider 记录。
 - 在保存前编辑每个模型的容量、文本/图片输入和 `reasoningEfforts`，并查看不含密钥的配置预览。
 - 所有界面文案支持中文和英文，跟随 Harness 语言设置。

--- a/docs/model-config-plugin-design.md
+++ b/docs/model-config-plugin-design.md
@@ -20,15 +20,15 @@
 |---|---|---|
 | 前端配置入口 | `ui-settings-models` 的 Models 页：三域 join（`llm.providers` + `settings.describe` + `credentials.describe`），注册于 `settings.section` 与 `settings.onboarding` | 无 |
 | 配置自定义端点 | `llm-pi-ai` 的 `CustomProviderCard`：`providers.<route>` 整段写入（`api`/`baseURL`/`models`），协议选项读自 adapter 自身 schema | 无 |
-| 拉取模型 | `llm.discoverModels` RPC（pi-ai discovery：catalog 路由从 registry 回答，未知路由走 `GET /models`）→ picker 采纳 | 无 |
+| 拉取模型 | `llm.discoverModels` RPC（pi-ai discovery：模型列表已知路由从 registry 回答，未知路由走 `GET /models`）→ picker 采纳 | 无 |
 | 每模型上下文 / 最大输出 | `ModelListEditor` 行内 disclosure：`contextWindow`、`maxTokens`（`K`/`M` 后缀，存纯计数） | 无 |
-| 模型目录（host 侧） | `llm.models` RPC：跨会话的每路由模型分组（设置面视图，与 `session.models` 同构） | 无 |
+| 模型列表（host 侧） | `llm.models` RPC：跨会话的每路由模型分组（设置面视图，与 `session.models` 同构） | 无 |
 | **每模型推理强度** | route 级 `reasoning`（pi-ai）/`reasoningEffort`（deepseek）已在既有卡片"自定义设置"折叠区可编辑；pi-ai profile 的**每模型** `reasoningEfforts`（级别 → wire 拼写）仅 `settings.yaml` 可写；`llm-deepseek` 的 `models` 条目根本不支持按模型 effort | **有：每模型级别的 UI 编辑面缺失** |
 | 保存与安全 | `settings.mutate`（path ops + `expectedRevision`）+ `describe({redactSecrets})`；API Key 走 `credentials.set` write-only（派生 `<ROUTE>_API_KEY`） | 无 |
 | 配置生效 | adapter 以 thunk 每操作重读；`llm/adapters-updated`、`settings/document-updated` 推送失效 | 无 |
 | 被会话使用 | `agent-default-model`（默认选择）+ `ui-model-selection`（`session.models` / `session.selectModel`） | 无 |
 
-**结论**：需求的运输与存储主体已由架构承载。仓库 [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) 明确否决过"统一 models bridge 插件"——provider 配置必须待在 adapter 自己的 settings 命名空间，目录声明只有四个字段。因此本插件设计的实质增量是：
+**结论**：需求的运输与存储主体已由架构承载。仓库 [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) 明确否决过"统一 models bridge 插件"——provider 配置必须待在 adapter 自己的 settings 命名空间，模型元数据声明只有四个字段。因此本插件设计的实质增量是：
 
 - **G1**：每模型推理强度等参数的 Web 编辑面（`reasoningEfforts` UI）；
 - **G2**：将散落能力组装为独立可安装的插件（独立 `settings.section` 入口 + host 侧最小支撑）。
@@ -58,7 +58,7 @@
 └──────────────────────────────────────────────────────────┘
 ```
 
-- **不新增协议适配器**（决策 D1）：自定义端点由 `llm-pi-ai` dormant 装载承担——它已实现 OpenAI-compatible 端点、协议表、模型 catalog、发现与推理方言。
+- **不新增协议适配器**（决策 D1）：自定义端点由 `llm-pi-ai` dormant 装载承担——它已实现 OpenAI-compatible 端点、协议表、模型列表、发现与推理方言。
 - **不新增 settings 桥**（决策 D2）：沿用 [web-config-plane 的否决](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md#alternatives-considered)；配置留在 adapter 自己的命名空间。
 
 ## 4. 配置模型（schema 设计）
@@ -76,7 +76,7 @@
 ```yaml
 providers:
   acme-gateway:
-    displayName: Acme Gateway      # 目录/UI 显示名
+    displayName: Acme Gateway      # provider/UI 显示名
     api: openai-completions        # 协议；未知路由必填
     baseURL: https://gateway.acme.example/v1
     apiKeyEnv: ACME_GATEWAY_API_KEY  # 凭据引用；UI 输入键时派生并写回
@@ -115,26 +115,33 @@ models:
 
 `llm.discoverModels` 只披露 `id`/`name`/`contextWindow`/`maxTokens`，**不披露推理能力**。picker 另从匹配到的 `models.dev` 记录读取推理信息：`reasoning: false` 写为 `reasoningEfforts: false`，可识别的 effort 选项写为 `reasoningEfforts` dict，没有推理信息时保持字段省略。用户可手动添加或编辑 effort；不提供“继承/禁用/声明”模式下拉框。这是 G1 的边界：发现是"候选"，参数是"声明"。
 
-### 4.5 models.dev 目录匹配
+### 4.5 models.dev 模型元数据匹配
 
-目录补全只在发现候选进入 picker 时执行，且一个目录记录是不可拆分的 provider 选择。匹配顺序固定为两层：
+模型元数据补全只在发现候选进入 picker 时执行，且一条元数据记录是不可拆分的 provider 选择。匹配顺序固定为两层：
 
-1. **模型名称识别官方 provider**：从模型 ID 的规范名称或 provider 前缀识别官方 provider；例如 `deepseek-*` → `deepseek`、`gpt-*`/`o1*`/`o3*`/`o4*` → `openai`、`grok-*`/`x-ai/grok-*`/`xai/grok-*`/`grok/grok-*` → `xai`、`claude-*` → `anthropic`、`gemini-*` → `google`。只有该 provider 存在同 ID 或去掉已知 provider 前缀后的目录 ID 时才采用；这一步只选择元数据来源，不改写发给端点的模型 ID。
-2. **默认 provider 选择**：官方 provider 没有对应目录记录时，在所有精确 ID 候选中按完整记录排序，先比较 `contextWindow` 升序，再比较 `maxTokens` 升序，最后按 provider ID 稳定排序，选择一条完整记录。缺失容量排在有容量的记录之后；不把不同 provider 的字段合成一条记录。
+1. **模型名称识别官方 provider**：从模型 ID 的规范名称或 provider 前缀识别官方 provider；例如 `deepseek-*` → `deepseek`、`gpt-*`/`o1*`/`o3*`/`o4*` → `openai`、`grok-*`/`x-ai/grok-*`/`xai/grok-*`/`grok/grok-*` → `xai`、`claude-*` → `anthropic`、`gemini-*` → `google`。只有该 provider 存在同 ID 或去掉已知 provider 前缀后的模型 ID 时才采用；这一步只选择元数据来源，不改写发给端点的模型 ID。
+2. **默认 provider 选择**：官方 provider 没有对应元数据记录时，在所有精确 ID 候选中按完整记录排序，先比较 `contextWindow` 升序，再比较 `maxTokens` 升序，最后按 provider ID 稳定排序，选择一条完整记录。缺失容量排在有容量的记录之后；不把不同 provider 的字段合成一条记录。
 
-模型 ID 没有目录记录时不做模糊匹配，保持发现结果可编辑。用户可在 picker 中选择其他完整 provider 记录；切换来源会整体替换该模型的目录字段，手工改过的字段保持用户值。endpoint hostname 与 API 协议不再覆盖模型名称识别结果，因为聚合代理的 hostname 和协议通常不能证明真实上游 provider。
+模型 ID 没有元数据记录时不做模糊匹配，保持发现结果可编辑。用户可在 picker 中选择其他完整 provider 记录；切换来源会整体替换该模型的元数据字段，手工改过的字段保持用户值。endpoint hostname 与 API 协议不再覆盖模型名称识别结果，因为聚合代理的 hostname 和协议通常不能证明真实上游 provider。
 
 ## 5. 端到端流程设计
 
 ### 5.1 入口注册（Client）
 
 - 注册 `settings.section`（"模型配置"页）：经 `ctx.slots.inject('settings.section', () => ctx.slots.register({ name: 'settings.section', … }))`——`inject` 等待声明、声明塌缩时移除贡献、重声明后重跑（应用顺序不受约束，`ui-settings-models` 即此形态）；`children` 声明本页所需槽位；数据经注入面（inject `connection`/`remote`，三域 RPC）进入，组件只拿 props 四份 share。
-- 页面 join 四域快照：`llm.providers`（configurable-provider 目录 + 活跃态）、`llm.models`（host 侧每路由模型分组）、`settings.describe({redactSecrets})`（分层+脱敏+`secrets` 槽位）、`credentials.describe`（configured/source/writable 徽标）。失效订阅：`settings/document-updated`、`credentials/updated`、`llm/adapters-updated`（转发后重取）。
+- 页面 join 四域快照：`llm.providers`（可配置 provider 列表 + 活跃态）、`llm.models`（host 侧每路由模型分组）、`settings.describe({redactSecrets})`（分层+脱敏+`secrets` 槽位）、`credentials.describe`（configured/source/writable 徽标）。失效订阅：`settings/document-updated`、`credentials/updated`、`llm/adapters-updated`（转发后重取）。
 - 若宿主已装载 `ui-settings-models`，则树内形态**不重复注册页面**，而是演进既有 Models 页（新增 G1 编辑面）；独立插件形态（out-of-tree）注册自己的 section，互斥由 profile 层禁用 `ui-settings-models` 行实现（决策 D4）。
 
-### 5.2 新增自定义端点
+### 5.2 端点编辑器
 
-复用 `CustomProviderCard` 形态：Provider ID（小写字母开头，作为 `providers.<route>` 键与派生凭据引用词干）、端点（baseURL）、协议（读自命名空间自身 schema 的 union，防漂移）、至少一个唯一 id 模型——三者门控创建。一次 `settings.mutate` 写入整段 profile + 一次 `credentials.set`（`<ROUTE>_API_KEY` 派生）。API Key 输入仅存在于组件内存，绝不进 `settings.yaml`。
+新增端点与编辑已保存端点共用一个 `EndpointEditor`。编辑器由端点字段、模型候选 picker、模型参数 draft、元数据来源选择和保存动作组成；模式只影响初始值、路由写入方式和凭据处理，不复制一套 UI 或匹配逻辑。
+
+- **新增模式**：Provider ID（英文字母开头，后续允许数字，作为 `providers.<route>` 键与派生凭据引用词干）、端点（baseURL）、协议（读自命名空间自身 schema 的 union，防漂移）、至少一个唯一 id 模型。初始没有模型候选；首次拉取后所有候选默认不勾选。保存一次 `settings.mutate` 写入整段 profile，再一次 `credentials.set` 写入 `<ROUTE>_API_KEY`；API Key 只存在于组件内存。
+- **编辑模式**：加载已保存 provider 的 displayName、baseURL、api、用户层 Header、有效模型列表和当前模型选择。端点字段、Header、模型和凭据在同一编辑器中编辑；路由 key 保持不变，displayName 改动只更新显示名。API Key 留空表示继续使用已有凭据，填写新值才更新凭据。
+- **重新拉取**：编辑模式和新增模式都通过 `llm.discoverModels` 获取候选，不直接写入 settings。编辑模式传递现有 provider route，使 adapter 能使用已保存凭据；用户输入的新 Key 优先用于本次拉取。重新拉取后，当前已勾选的模型保持勾选，新候选默认不勾选；当前勾选但端点未返回的模型保留在列表中，避免刷新误删。
+- **恢复继承**：已存在用户层 `models` 覆盖且存在 base 模型列表时，编辑器保留“恢复继承”动作，显式执行 `unset providers.<route>.models`，恢复 base 层模型列表。
+- **保存**：新增模式写入整段 profile；编辑模式只写入发生变化的 displayName、api、baseURL、models、headers 和必要的 apiKeyEnv 字段，并携带 `expectedRevision`。只有保存成功后才调用 `onSaved` 刷新设置快照。
+- **布局**：顶部选择已保存端点或进入“新增端点”；两种模式下端点字段、重新拉取、模型选择、参数编辑、配置预览和保存按钮位置一致。
 
 ### 5.3 拉取模型
 
@@ -153,7 +160,7 @@ models:
 | 推理强度 | models.dev 回填的级别行列表；未声明时可通过“添加级别”控件创建；级别名 + wire 拼写输入 | 同上 |
 
 - **落盘形态与既有编辑器一致**：持 draft 数组，一次 `settings.mutate` 写整组 `models`（或重置时 unset 该数组）——逐索引 path op 在数组位移时脆弱，不使用。
-- 推理强度由目录记录或用户声明决定：目录明确非推理时写 `false`，目录提供 effort 时写声明 dict，目录没有推理信息时保持省略。省略或 `false` 时仍渲染“添加级别”控件，用户选择一个级别后才创建声明 dict；声明 dict 时渲染**已声明**级别、同一“添加级别”入口和清除覆盖按钮。级别候选读自命名空间 schema 的 dict 键约束（见 4.3），排除已声明者；省略某级别即"不支持"，不做隐式默认。
+- 推理强度由模型元数据记录或用户声明决定：元数据明确非推理时写 `false`，元数据提供 effort 时写声明 dict，元数据没有推理信息时保持省略。省略或 `false` 时仍渲染“添加级别”控件，用户选择一个级别后才创建声明 dict；声明 dict 时渲染**已声明**级别、同一“添加级别”入口和清除覆盖按钮。级别候选读自命名空间 schema 的 dict 键约束（见 4.3），排除已声明者；省略某级别即"不支持"，不做隐式默认。
 - `off` 三态 UI：不声明（无行）/ 空值行（`off:`，按方言映射）/ 带值行。清空非 `off` 级别的拼写 = 删除该级别行（unset），不写空串——空串与空 dict 都是被拒绝的非法值。
 - 校验在 draft 上先行（重复 id、非法级别、`off` 之外空值、非正整数容量），写入前再经 schema；行内报错。
 - 继承视图：`base` 层的 models 数组在用户层未覆盖时以继承态显示；首次编辑把完整数组物化进用户层；重置 = unset 该数组。
@@ -165,20 +172,20 @@ models:
 ### 5.6 生效与联动
 
 - adapter 每次 `stream()`/`resolveModelInfo()` 经 thunk 重读命名空间；一次编辑在**下一次请求**生效，运行中的流保持其开始时的快照。
-- 注册级事实（路由集、retryPolicy、目录声明）变化时，pi-ai 以 `replace` 原子更新注册；`llm/adapters-updated` 在每次拓扑提交后发出，客户端据此刷新 join。
-- 会话使用链路（复用）：`agent-default-model`（默认选择：provider/model/effort）→ 新会话 → `ui-model-selection`（`session.models` 目录 + `session.selectModel`）→ 下一次 prompt 组装时 `installModelSelection` 应用。
+- 注册级事实（路由集、retryPolicy、模型列表声明）变化时，pi-ai 以 `replace` 原子更新注册；`llm/adapters-updated` 在每次拓扑提交后发出，客户端据此刷新 join。
+- 会话使用链路（复用）：`agent-default-model`（默认选择：provider/model/effort）→ 新会话 → `ui-model-selection`（`session.models` 模型列表 + `session.selectModel`）→ 下一次 prompt 组装时 `installModelSelection` 应用。
 
 ## 6. 关键设计决策
 
 | # | 决策 | 理由 | 引用 |
 |---|---|---|---|
 | D1 | 不新增协议适配器，复用 `llm-pi-ai` dormant 装载 | 自定义端点/发现/推理方言已由 pi-ai 实现；新 adapter 重复其协议表 | [llm-pi-ai README](../deepseek-harness/packages/llm/llm-pi-ai/README.md) |
-| D2 | 不建统一 models bridge；配置留在 adapter 命名空间 | 目录四字段 + 每插件命名空间已给 UI 一切所需；bridge 重引入 adapter 映射间接 | [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) |
-| D3 | 每模型推理强度落在 `reasoningEfforts`（pi-ai 语义）；deepseek 按需扩展单字段 | 级别是 opaque id、wire 拼写适配器拥有；off 三态不可用空值消除 | [pi-ai catalog 语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#catalog-resolution) |
+| D2 | 不建统一 models bridge；配置留在 adapter 命名空间 | 模型元数据四字段 + 每插件命名空间已给 UI 一切所需；bridge 重引入 adapter 映射间接 | [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) |
+| D3 | 每模型推理强度落在 `reasoningEfforts`（pi-ai 语义）；deepseek 按需扩展单字段 | 级别是 opaque id、wire 拼写适配器拥有；off 三态不可用空值消除 | [pi-ai 模型元数据语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#catalog-resolution) |
 | D4 | 树内形态演进 `ui-settings-models`；独立插件形态注册自己的 section，互斥由 profile 层禁用 `ui-settings-models` 行实现 | 双模型页互相漂移；槽位是唯一组合通道 | [ui-settings README](../deepseek-harness/packages/client/ui-settings/README.md) |
 | D5 | UI 手写卡片而非 schema 通用渲染器 | 通用渲染器已被实现并否决：无层次、不可用 | [web-config-plane 笔记](../deepseek-harness/.agents/notes/implemented/architecture/2026-07-30-web-config-plane.md) |
-| D6 | 推理能力仅从匹配目录记录回填，缺失时保持省略 | 发现端点本身不披露 effort；无目录事实时不猜测，用户可手工声明 | [pi-ai 发现语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#endpoint-interrogation) |
-| D7 | 目录歧义按官方 provider 优先、整条默认记录回退 | 聚合代理不能由 hostname 证明上游；跨 provider 拼字段会制造不存在的能力组合 | 本文 4.5 |
+| D6 | 推理能力仅从匹配模型元数据记录回填，缺失时保持省略 | 发现端点本身不披露 effort；无元数据事实时不猜测，用户可手工声明 | [pi-ai 发现语义](../deepseek-harness/packages/llm/llm-pi-ai/README.md#endpoint-interrogation) |
+| D7 | 元数据歧义按官方 provider 优先、整条默认记录回退 | 聚合代理不能由 hostname 证明上游；跨 provider 拼字段会制造不存在的能力组合 | 本文 4.5 |
 
 ## 7. 错误处理与安全
 
@@ -191,7 +198,7 @@ models:
 ## 8. 事件与扩展点
 
 - 复用事件：`llm/adapters-updated`（拓扑）、`settings/updated` + `settings/document-updated`（命名空间）、`credentials/updated`（徽标刷新）。
-- 复用扩展点：`ctx.llm.registerConfigurableProviders`（目录）、`registerModelDiscovery`（发现）、`ctx.settings.register`（命名空间）、`settings.section`（页面槽位）、`agent-default-model` + `session.selectModel`（使用链路）。
+- 复用扩展点：`ctx.llm.registerConfigurableProviders`（provider 列表）、`registerModelDiscovery`（发现）、`ctx.settings.register`（命名空间）、`settings.section`（页面槽位）、`agent-default-model` + `session.selectModel`（使用链路）。
 - 本插件不新增事件；若 deepseek 按模型 effort（D3 扩展）落地，也只改其 schema 与 resolve 路径，不动事件面。
 
 ## 9. 模型体验（Model Experience）
@@ -203,16 +210,17 @@ models:
 ## 10. 验证方案
 
 - **单元**：schema 校验（重复 id、`reasoningEfforts` 非法形态、off 三态）、解析拒绝、draft → path op 生成、容量 `K/M` 解析与最短回写、凭据派生与 ownership 判定。
-- **目录匹配**：官方模型名命中 provider、带 provider 前缀的别名归一化、官方记录缺失时整条记录的最小排序、切换 provider 不跨记录拼字段、未知 ID 保持手工编辑。
-- **REAL-composition**：boot 测试专用 cordis.yml 经 Loader 与 app/process 装载，断言"写 profile → 路由注册 → `llm.providers` 目录生效 → 下一次请求使用新配置"。
-- **组件（jsdom）**：ProviderCard 门控、拉取携带表单当前值、picker 采纳不覆盖调优行、目录推理回填、手动添加或清除每模型 effort、冲突重试、只读姿态。
+- **模型元数据匹配**：官方模型名命中 provider、带 provider 前缀的别名归一化、官方记录缺失时整条记录的最小排序、切换 provider 不跨记录拼字段、未知 ID 保持手工编辑。
+- **端点编辑器**：新增与编辑共用字段和模型 picker、编辑模式重新拉取使用已保存凭据、新模型默认不勾选、已勾选模型在刷新后保留、编辑保存使用路径 ops 且不覆盖无关 profile 字段。
+- **REAL-composition**：boot 测试专用 cordis.yml 经 Loader 与 app/process 装载，断言"写 profile → 路由注册 → `llm.providers` 列表生效 → 下一次请求使用新配置"。
+- **组件（jsdom）**：ProviderCard 门控、拉取携带表单当前值、picker 采纳不覆盖调优行、模型元数据推理回填、手动添加或清除每模型 effort、冲突重试、只读姿态。
 - **e2e 快照（keyless）**：仿照 `apps/web/tests/models-settings.e2e.ts` 钉死"新增自定义端点 → 拉取 → 配置每模型参数 → 设置页渲染"全链路，scaffold `harnessHome`。
 - **覆盖门**：client 包进每文件 100% 覆盖门；`test:gui` + `DSH_SNAPSHOT=replay test:web`。
 
 ## 11. 已知限制与后续
 
 - 拉取仅覆盖 OpenAI-compatible `GET /models`；其他协议手编。
-- 目录没有 effort 信息时 UI 不猜测能力；用户手动声明后只提供其已添加的级别。
+- 模型元数据没有 effort 信息时 UI 不猜测能力；用户手动声明后只提供其已添加的级别。
 - 独立插件形态与 `ui-settings-models` 互斥（D4）：共存时双页面由同一命名空间驱动，修改相互可见但 UX 重复。
 - schema-generic 的"高级参数"（retryPolicy、超时等）延续既有姿态：留在 `settings.yaml`。
 

--- a/src/client.js
+++ b/src/client.js
@@ -6,8 +6,8 @@ window.__ModuleLoader__.load({
 
     const NS = 'settings.modelConfig'
     const EFFORTS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
-    const MODELS_DEV_CATALOG_URL = 'https://models.dev/api.json'
-    let modelsDevCatalogPromise
+    const MODELS_DEV_METADATA_URL = 'https://models.dev/api.json'
+    let modelsDevMetadataPromise
     const en = {
       nav: 'Advanced model config',
       title: 'Advanced model config',
@@ -44,6 +44,7 @@ window.__ModuleLoader__.load({
       inputText: 'Text',
       inputImage: 'Image',
       endpointTitle: 'Add custom endpoint',
+      editEndpoint: 'Edit endpoint',
       endpointDescription: 'Fetch candidates through the OpenAI-compatible model-list endpoint.',
       endpointName: 'Name',
       endpointNamePlaceholder: 'AcmeGateway',
@@ -64,6 +65,7 @@ window.__ModuleLoader__.load({
       headerValueInvalid: 'The header content contains unsupported characters. Remove emoji, null characters, and line breaks.',
       endpointKey: 'API key',
       endpointKeyPlaceholder: 'Used only to fetch models and store the credential',
+      endpointKeyExistingPlaceholder: 'Leave blank to keep the existing credential',
       endpointNameRequired: 'Enter an endpoint name.',
       endpointNameInvalid: 'The name must start with an English letter and contain only English letters and numbers.',
       endpointUrlRequired: 'Enter an endpoint URL.',
@@ -74,7 +76,9 @@ window.__ModuleLoader__.load({
       routeTaken: 'Route {route} already exists.',
       routePreview: 'Uses route {route} and credential reference {ref}.',
       fetchModels: 'Fetch available models',
+      refreshModels: 'Refresh models',
       fetching: 'Fetching…',
+      refreshingModels: 'Refreshing…',
       discoveryEmpty: 'The endpoint returned no models to add.',
       chooseModels: 'Choose models to add',
       selectAll: 'Select all',
@@ -85,14 +89,15 @@ window.__ModuleLoader__.load({
       keyPreviewNotice: 'The API key is saved separately and is not shown here. Header content is saved in settings, but is not sent when fetching the model list.',
       cancel: 'Cancel',
       confirmSave: 'Confirm and save',
+      saveChanges: 'Save changes',
       retryKey: 'Retry saving API key',
-      catalogApplied: 'Completed metadata for {matched} models. Official providers: {official}; default providers: {ambiguous}; no catalog match: {unmatched}.',
-      catalogUnavailable: 'Could not load models.dev metadata. The endpoint results remain editable.',
-      catalogSource: 'Catalog source',
-      catalogSourceDescription: 'Each option is one provider record. Switching it replaces all catalog-derived fields for this model.',
-      catalogDefault: 'Default provider: {provider} ({context}/{output})',
-      catalogOfficial: 'Official provider: {provider} ({context}/{output})',
-      catalogProvider: '{provider} ({context}/{output})',
+      metadataApplied: 'Completed metadata for {matched} models. Official providers: {official}; default providers: {ambiguous}; no metadata match: {unmatched}.',
+      metadataUnavailable: 'Could not load models.dev metadata. The endpoint results remain editable.',
+      metadataSource: 'Metadata source',
+      metadataSourceDescription: 'Each option is one provider metadata record. Switching it replaces all metadata fields for this model.',
+      metadataDefault: 'Default provider: {provider} ({context}/{output})',
+      metadataOfficial: 'Official provider: {provider} ({context}/{output})',
+      metadataProvider: '{provider} ({context}/{output})',
       reasoningInvalid: 'Reasoning efforts must inherit, be disabled, or be an effort list.',
       reasoningEmpty: 'A declared reasoning list needs at least one effort.',
       reasoningOffOnly: 'A list with only off has no usable reasoning effort.',
@@ -139,6 +144,7 @@ window.__ModuleLoader__.load({
       inputText: '文本',
       inputImage: '图片',
       endpointTitle: '新增自定义端点',
+      editEndpoint: '编辑端点',
       endpointDescription: '使用 OpenAI 兼容的模型列表接口获取候选模型。',
       endpointName: '名称',
       endpointNamePlaceholder: 'AcmeGateway',
@@ -159,6 +165,7 @@ window.__ModuleLoader__.load({
       headerValueInvalid: 'Header 内容包含不支持的字符，请移除表情、空字符和换行符。',
       endpointKey: 'API Key',
       endpointKeyPlaceholder: '仅用于获取模型和保存凭据',
+      endpointKeyExistingPlaceholder: '留空表示继续使用已有凭据',
       endpointNameRequired: '请填写端点名称。',
       endpointNameInvalid: '名称必须以英文字母开头，只能包含英文字母和数字。',
       endpointUrlRequired: '请填写端点 URL。',
@@ -169,7 +176,9 @@ window.__ModuleLoader__.load({
       routeTaken: '路由 {route} 已存在。',
       routePreview: '将使用路由 {route} 和凭据引用 {ref}。',
       fetchModels: '获取可用模型',
+      refreshModels: '重新拉取模型',
       fetching: '获取中…',
+      refreshingModels: '重新拉取中…',
       discoveryEmpty: '端点没有返回可添加的模型。',
       chooseModels: '选择要添加的模型',
       selectAll: '全选',
@@ -180,14 +189,15 @@ window.__ModuleLoader__.load({
       keyPreviewNotice: 'API Key 会单独保存，不会显示在这里。Header 内容会写入配置，但获取模型列表时不会发送。',
       cancel: '取消',
       confirmSave: '确认并保存',
+      saveChanges: '保存修改',
       retryKey: '重试保存 API Key',
-      catalogApplied: '已为 {matched} 个模型补全参数；官方 provider {official} 个，默认 provider {ambiguous} 个，没有目录记录 {unmatched} 个。',
-      catalogUnavailable: '无法加载 models.dev 元数据；端点返回的模型仍可编辑。',
-      catalogSource: '目录来源',
-      catalogSourceDescription: '每个选项都是一个完整的 provider 记录；切换后会整体替换该模型的目录参数。',
-      catalogDefault: '默认 provider：{provider}（{context}/{output}）',
-      catalogOfficial: '官方 provider：{provider}（{context}/{output}）',
-      catalogProvider: '{provider}（{context}/{output}）',
+      metadataApplied: '已为 {matched} 个模型补全参数；官方 provider {official} 个，默认 provider {ambiguous} 个，没有元数据记录 {unmatched} 个。',
+      metadataUnavailable: '无法加载 models.dev 元数据；端点返回的模型仍可编辑。',
+      metadataSource: '元数据来源',
+      metadataSourceDescription: '每个选项都是一个完整的 provider 元数据记录；切换后会整体替换该模型的元数据参数。',
+      metadataDefault: '默认 provider：{provider}（{context}/{output}）',
+      metadataOfficial: '官方 provider：{provider}（{context}/{output}）',
+      metadataProvider: '{provider}（{context}/{output}）',
       reasoningInvalid: '推理强度必须是“继承”、禁用或级别列表。',
       reasoningEmpty: '已声明推理强度时至少选择一个级别。',
       reasoningOffOnly: '仅声明关闭级别没有可用的推理强度。',
@@ -218,27 +228,27 @@ window.__ModuleLoader__.load({
       background: 'transparent', color: 'inherit', cursor: 'pointer', font: 'inherit',
     }
 
-    function loadModelsDevCatalog() {
-      if (modelsDevCatalogPromise === undefined) {
-        modelsDevCatalogPromise = fetch(MODELS_DEV_CATALOG_URL, { cache: 'force-cache' }).then(async response => {
+    function loadModelsDevMetadata() {
+      if (modelsDevMetadataPromise === undefined) {
+        modelsDevMetadataPromise = fetch(MODELS_DEV_METADATA_URL, { cache: 'force-cache' }).then(async response => {
           if (!response.ok) throw new Error(`models.dev returned HTTP ${response.status}`)
           return response.json()
         }).catch(error => {
-          modelsDevCatalogPromise = undefined
+          modelsDevMetadataPromise = undefined
           throw error
         })
       }
-      return modelsDevCatalogPromise
+      return modelsDevMetadataPromise
     }
 
-    function positiveCatalogLimit(value) {
+    function positiveMetadataLimit(value) {
       return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined
     }
 
-    function modelRecordCandidates(catalog, id) {
-      if (catalog === null || typeof catalog !== 'object') return []
+    function metadataRecordCandidates(metadata, id) {
+      if (metadata === null || typeof metadata !== 'object') return []
       const matches = []
-      for (const [providerKey, provider] of Object.entries(catalog)) {
+      for (const [providerKey, provider] of Object.entries(metadata)) {
         if (provider === null || typeof provider !== 'object') continue
         const models = provider.models
         const model = models !== null && typeof models === 'object' ? models[id] : undefined
@@ -266,27 +276,27 @@ window.__ModuleLoader__.load({
       ['alibaba', /^qwen(?:[-/.]|$)/],
     ]
 
-    function officialCatalogProviderForModel(id) {
+    function officialMetadataProviderForModel(id) {
       const normalized = id.toLowerCase()
       const bare = normalized.includes('/') ? normalized.slice(normalized.lastIndexOf('/') + 1) : normalized
       return OFFICIAL_PROVIDER_RULES.find(([, rule]) => rule.test(normalized) || rule.test(bare))?.[0]
     }
 
-    function catalogModelIdVariants(id) {
+    function metadataModelIdVariants(id) {
       const variants = [id]
       if (id.includes('/')) variants.push(id.slice(id.lastIndexOf('/') + 1))
       return [...new Set(variants)]
     }
 
-    function catalogProviderModel(catalog, providerId, id) {
-      if (catalog === null || typeof catalog !== 'object') return undefined
-      for (const [providerKey, provider] of Object.entries(catalog)) {
+    function metadataProviderModel(metadata, providerId, id) {
+      if (metadata === null || typeof metadata !== 'object') return undefined
+      for (const [providerKey, provider] of Object.entries(metadata)) {
         if (provider === null || typeof provider !== 'object') continue
         const currentProviderId = typeof provider.id === 'string' && provider.id !== '' ? provider.id : providerKey
         if (currentProviderId !== providerId) continue
         const models = provider.models
         if (models === null || typeof models !== 'object') return undefined
-        for (const variant of catalogModelIdVariants(id)) {
+        for (const variant of metadataModelIdVariants(id)) {
           const key = Object.keys(models).find(modelId => modelId === variant || modelId.toLowerCase() === variant.toLowerCase())
           const model = key === undefined ? undefined : models[key]
           if (model !== null && typeof model === 'object') return { providerId, modelId: key, model }
@@ -296,20 +306,20 @@ window.__ModuleLoader__.load({
       return undefined
     }
 
-    function catalogLimit(model, field) {
+    function metadataLimit(model, field) {
       const limit = model !== null && typeof model === 'object'
         && model.limit !== null && typeof model.limit === 'object' ? model.limit : {}
-      return positiveCatalogLimit(limit[field])
+      return positiveMetadataLimit(limit[field])
     }
 
-    function catalogLimitText(model, field) {
-      const value = catalogLimit(model, field)
+    function metadataLimitText(model, field) {
+      const value = metadataLimit(model, field)
       return value === undefined ? '?' : String(value)
     }
 
-    function compareCatalogLimits(left, right, field) {
-      const leftValue = catalogLimit(left, field)
-      const rightValue = catalogLimit(right, field)
+    function compareMetadataLimits(left, right, field) {
+      const leftValue = metadataLimit(left, field)
+      const rightValue = metadataLimit(right, field)
       if (leftValue === undefined && rightValue === undefined) return 0
       if (leftValue === undefined) return 1
       if (rightValue === undefined) return -1
@@ -321,20 +331,20 @@ window.__ModuleLoader__.load({
     }
 
     // Rank complete provider records; never combine fields from different providers.
-    function defaultCatalogCandidate(candidates) {
+    function defaultMetadataCandidate(candidates) {
       return [...candidates].sort((left, right) => {
-        const context = compareCatalogLimits(left.model, right.model, 'context')
+        const context = compareMetadataLimits(left.model, right.model, 'context')
         if (context !== 0) return context
-        const output = compareCatalogLimits(left.model, right.model, 'output')
+        const output = compareMetadataLimits(left.model, right.model, 'output')
         if (output !== 0) return output
         return left.providerId.localeCompare(right.providerId)
       })[0]
     }
 
-    function catalogMatchForEndpoint(catalog, id) {
-      const exactCandidates = modelRecordCandidates(catalog, id)
-      const officialProvider = officialCatalogProviderForModel(id)
-      const official = officialProvider === undefined ? undefined : catalogProviderModel(catalog, officialProvider, id)
+    function metadataMatchForEndpoint(metadata, id) {
+      const exactCandidates = metadataRecordCandidates(metadata, id)
+      const officialProvider = officialMetadataProviderForModel(id)
+      const official = officialProvider === undefined ? undefined : metadataProviderModel(metadata, officialProvider, id)
       const exactOfficial = officialProvider === undefined
         ? undefined
         : exactCandidates.find(candidate => candidate.providerId === officialProvider)
@@ -354,7 +364,7 @@ window.__ModuleLoader__.load({
       if (candidates.length === 1) {
         return { candidates, selection: providerSelection(candidates[0].providerId), reason: 'unique' }
       }
-      const defaultCandidate = defaultCatalogCandidate(candidates)
+      const defaultCandidate = defaultMetadataCandidate(candidates)
       return {
         candidates,
         selection: defaultCandidate === undefined ? undefined : providerSelection(defaultCandidate.providerId),
@@ -362,14 +372,14 @@ window.__ModuleLoader__.load({
       }
     }
 
-    function catalogRecordForSelection(match, selection) {
+    function metadataRecordForSelection(match, selection) {
       if (match === undefined) return undefined
       const selected = selection === undefined ? match.selection : selection
       const candidate = match.candidates.find(item => providerSelection(item.providerId) === selected)
       return candidate === undefined ? match.candidates[0]?.model : candidate.model
     }
 
-    function reasoningEffortsFromCatalog(model) {
+    function reasoningEffortsFromMetadata(model) {
       if (model.reasoning === false) return false
       const options = Array.isArray(model.reasoning_options) ? model.reasoning_options : []
       const effort = options.find(option => option !== null && typeof option === 'object' && option.type === 'effort')
@@ -383,20 +393,20 @@ window.__ModuleLoader__.load({
     }
 
     function enrichDiscoveredModel(candidate, match, selection) {
-      const record = catalogRecordForSelection(match, selection)
+      const record = metadataRecordForSelection(match, selection)
       if (record === undefined) return { ...candidate }
       const limit = record.limit !== null && typeof record.limit === 'object' ? record.limit : {}
       const modalities = record.modalities !== null && typeof record.modalities === 'object' ? record.modalities : {}
       const input = Array.isArray(modalities.input) ? modalities.input.filter(value => value === 'text' || value === 'image') : []
-      const reasoningEfforts = reasoningEffortsFromCatalog(record)
+      const reasoningEfforts = reasoningEffortsFromMetadata(record)
       return {
         ...candidate,
         ...candidate.name === undefined && typeof record.name === 'string' ? { name: record.name } : {},
-        ...candidate.contextWindow === undefined && positiveCatalogLimit(limit.context) !== undefined
-          ? { contextWindow: positiveCatalogLimit(limit.context) }
+        ...candidate.contextWindow === undefined && positiveMetadataLimit(limit.context) !== undefined
+          ? { contextWindow: positiveMetadataLimit(limit.context) }
           : {},
-        ...candidate.maxTokens === undefined && positiveCatalogLimit(limit.output) !== undefined
-          ? { maxTokens: positiveCatalogLimit(limit.output) }
+        ...candidate.maxTokens === undefined && positiveMetadataLimit(limit.output) !== undefined
+          ? { maxTokens: positiveMetadataLimit(limit.output) }
           : {},
         ...input.length > 0 ? { input } : {},
         ...reasoningEfforts === undefined ? {} : { reasoningEfforts },
@@ -633,7 +643,7 @@ window.__ModuleLoader__.load({
 
     function ModelRow({
       model, index, onChange, disabled, lockId = false,
-      catalogChoice, catalogCandidates = [], catalogDefaultProvider, catalogOfficialProvider, onCatalogChoice, t,
+      metadataChoice, metadataCandidates = [], metadataDefaultProvider, metadataOfficialProvider, onMetadataChoice, t,
     }) {
       const patch = changes => {
         const next = { ...model, ...changes }
@@ -649,33 +659,33 @@ window.__ModuleLoader__.load({
       }
       return h('details', { style: { border: '1px solid var(--dsw-alias-border-l2)', borderRadius: '8px', padding: '8px' } },
         h('summary', { style: { cursor: 'pointer', fontSize: '14px' } }, typeof model.id === 'string' && model.id !== '' ? model.id : t('modelIndex', { index: index + 1 })),
-        catalogCandidates.length > 1 ? h('div', { style: { display: 'flex', flexDirection: 'column', gap: '5px', paddingTop: '10px' } },
-          h(Field, { label: t('catalogSource') }, h('select', {
+        metadataCandidates.length > 1 ? h('div', { style: { display: 'flex', flexDirection: 'column', gap: '5px', paddingTop: '10px' } },
+          h(Field, { label: t('metadataSource') }, h('select', {
             style: inputStyle,
-            value: catalogChoice ?? '',
+            value: metadataChoice ?? '',
             disabled,
-            onChange: event => onCatalogChoice?.(event.target.value),
-          }, catalogCandidates.map(candidate => h('option', {
+            onChange: event => onMetadataChoice?.(event.target.value),
+          }, metadataCandidates.map(candidate => h('option', {
             key: candidate.providerId,
             value: providerSelection(candidate.providerId),
-          }, candidate.providerId === catalogDefaultProvider
-            ? t('catalogDefault', {
+          }, candidate.providerId === metadataDefaultProvider
+            ? t('metadataDefault', {
               provider: candidate.providerId,
-              context: catalogLimitText(candidate.model, 'context'),
-              output: catalogLimitText(candidate.model, 'output'),
+              context: metadataLimitText(candidate.model, 'context'),
+              output: metadataLimitText(candidate.model, 'output'),
             })
-            : candidate.providerId === catalogOfficialProvider
-              ? t('catalogOfficial', {
+            : candidate.providerId === metadataOfficialProvider
+              ? t('metadataOfficial', {
                 provider: candidate.providerId,
-                context: catalogLimitText(candidate.model, 'context'),
-                output: catalogLimitText(candidate.model, 'output'),
+                context: metadataLimitText(candidate.model, 'context'),
+                output: metadataLimitText(candidate.model, 'output'),
               })
-            : t('catalogProvider', {
+            : t('metadataProvider', {
               provider: candidate.providerId,
-              context: catalogLimitText(candidate.model, 'context'),
-              output: catalogLimitText(candidate.model, 'output'),
+              context: metadataLimitText(candidate.model, 'context'),
+              output: metadataLimitText(candidate.model, 'output'),
             }))))),
-          h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, t('catalogSourceDescription')),
+          h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, t('metadataSourceDescription')),
         ) : null,
         h('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '10px', paddingTop: '10px' } },
           h(Field, { label: t('modelId') }, h('input', {
@@ -713,68 +723,99 @@ window.__ModuleLoader__.load({
       )
     }
 
-    function NewEndpointCard({ api, namespace, taken, writable, onCancel, onSaved, t }) {
-      const [endpoint, setEndpoint] = useState({ name: '', baseURL: '', api: 'openai-completions', apiKey: '', headers: [] })
-      const [candidates, setCandidates] = useState(undefined)
-      const [selected, setSelected] = useState(new Set())
-      const [modelDrafts, setModelDrafts] = useState({})
-      const [catalogMatches, setCatalogMatches] = useState({})
-      const [catalogSelections, setCatalogSelections] = useState({})
+    function EndpointEditor({
+      api, namespace, provider, initial, taken, writable, canRestoreInheritance, onCancel, onSaved, t,
+    }) {
+      const editing = provider !== undefined
+      const initialModels = Array.isArray(initial.models) ? initial.models.map(copyModel) : []
+      const inheritedHeaders = Array.isArray(initial.inheritedHeaders) ? initial.inheritedHeaders : []
+      const initialHeaders = Array.isArray(initial.headers) ? initial.headers : []
+      const [endpoint, setEndpoint] = useState({
+        name: initial.name ?? '',
+        baseURL: initial.baseURL ?? '',
+        api: initial.api ?? 'openai-completions',
+        apiKey: '',
+        headers: initialHeaders.map(row => ({ ...row })),
+      })
+      const [candidates, setCandidates] = useState(editing ? initialModels : undefined)
+      const [selected, setSelected] = useState(editing ? new Set(initialModels.map(model => model.id)) : new Set())
+      const [modelDrafts, setModelDrafts] = useState(editing
+        ? Object.fromEntries(initialModels.map(model => [model.id, { ...model }]))
+        : {})
+      const [metadataMatches, setMetadataMatches] = useState({})
+      const [metadataSelections, setMetadataSelections] = useState({})
       const [busy, setBusy] = useState(false)
       const [failure, setFailure] = useState(undefined)
-      const [catalogNotice, setCatalogNotice] = useState(undefined)
-      const [profileCreated, setProfileCreated] = useState(false)
-      const route = endpoint.name.toLowerCase()
-      const keyRef = route === '' ? '' : `${route.toUpperCase()}_API_KEY`
+      const [metadataNotice, setMetadataNotice] = useState(undefined)
+      const [settingsSaved, setSettingsSaved] = useState(false)
+      const route = editing ? provider : endpoint.name.toLowerCase()
+      const keyRef = editing
+        ? (initial.apiKeyEnv ?? `${route.toUpperCase()}_API_KEY`)
+        : route === '' ? '' : `${route.toUpperCase()}_API_KEY`
       const nameError = endpoint.name.length === 0
         ? t('endpointNameRequired')
         : /^[A-Za-z][A-Za-z0-9]*$/.test(endpoint.name) ? undefined : t('endpointNameInvalid')
       const urlError = endpoint.baseURL.length === 0 ? t('endpointUrlRequired') : endpointUrlError(endpoint.baseURL, t)
-      const keyError = apiKeyError(endpoint.apiKey, t)
+      const keyError = editing && endpoint.apiKey.trim() === '' ? undefined : apiKeyError(endpoint.apiKey, t)
       const requestHeadersError = headersError(endpoint.headers, t)
-      const routeTaken = taken.includes(route)
+      const routeTaken = !editing && taken.includes(route)
       const readyToFetch = nameError === undefined && urlError === undefined && keyError === undefined
         && requestHeadersError === undefined && !routeTaken
+      const readyToSave = nameError === undefined && keyError === undefined && requestHeadersError === undefined
+        && !routeTaken && (urlError === undefined || (editing && endpoint.baseURL.trim() === '' && (initial.baseURL ?? '') === ''))
       const selectedModels = candidates === undefined ? [] : candidates
         .filter(model => selected.has(model.id))
         .map(model => modelDrafts[model.id] ?? { ...model })
+      const effectiveHeaders = headersObject(endpoint.headers, inheritedHeaders)
+      const initialEffectiveHeaders = headersObject(initialHeaders, inheritedHeaders)
+      const modelsChanged = !jsonEqual(selectedModels, initialModels)
+      const headersChanged = !headersEqual(effectiveHeaders, initialEffectiveHeaders)
+      const endpointChanged = !editing || endpoint.name !== (initial.name ?? '')
+        || endpoint.baseURL.trim() !== (initial.baseURL ?? '')
+        || endpoint.api !== (initial.api ?? '') || modelsChanged || headersChanged
+      const keyChanged = endpoint.apiKey.trim() !== ''
       const profile = {
         displayName: endpoint.name,
         apiKeyEnv: keyRef,
         api: endpoint.api,
         baseURL: endpoint.baseURL.trim(),
         models: selectedModels.map(copyModel),
-        ...Object.keys(headersObject(endpoint.headers)).length === 0 ? {} : { headers: headersObject(endpoint.headers) },
+        ...Object.keys(effectiveHeaders).length === 0 ? {} : { headers: effectiveHeaders },
       }
       const preview = {
         'llm-pi-ai': { providers: { [route]: profile } },
-        credentials: { [keyRef]: '[write-only]' },
+        credentials: { [keyRef]: keyChanged ? '[write-only]' : '[unchanged]' },
       }
       const update = (field, value) => {
         setEndpoint(current => ({ ...current, [field]: value }))
-        setCandidates(undefined)
-        setSelected(new Set())
-        setModelDrafts({})
-        setCatalogMatches({})
-        setCatalogSelections({})
+        setMetadataMatches({})
+        setMetadataSelections({})
+        if (!editing) {
+          setCandidates(undefined)
+          setSelected(new Set())
+          setModelDrafts({})
+        }
         setFailure(undefined)
-        setCatalogNotice(undefined)
+        setMetadataNotice(undefined)
       }
       const fetchModels = async () => {
         setBusy(true)
         setFailure(undefined)
-        setCatalogNotice(undefined)
+        setMetadataNotice(undefined)
         try {
-          const [response, catalog] = await Promise.all([
+          const selectedBeforeFetch = new Set(selected)
+          const draftsBeforeFetch = modelDrafts
+          const [response, metadata] = await Promise.all([
             api.llm.discoverModels({
-              settingsNs: 'llm-pi-ai',
-              baseURL: endpoint.baseURL.trim(),
+               settingsNs: 'llm-pi-ai',
+               ...editing ? { provider } : {},
+               baseURL: endpoint.baseURL.trim(),
               // Model listings commonly remain OpenAI-shaped even when the
               // generation endpoint speaks Anthropic Messages.
               api: endpoint.api === 'anthropic-messages' ? 'openai-completions' : endpoint.api,
-              apiKey: endpoint.apiKey.trim(),
-            }),
-            loadModelsDevCatalog().catch(() => undefined),
+               ...endpoint.apiKey.trim() === '' ? {} : { apiKey: endpoint.apiKey.trim() },
+             }),
+            loadModelsDevMetadata().catch(() => undefined),
           ])
           if (!response.result.ok) {
             setFailure(response.result.error.message)
@@ -785,11 +826,11 @@ window.__ModuleLoader__.load({
             setFailure(t('discoveryEmpty'))
             return
           }
-          const prepared = catalog === undefined
+          const prepared = metadata === undefined
             ? models.map(candidate => ({ candidate, match: undefined }))
             : models.map(candidate => {
               const match = {
-                ...catalogMatchForEndpoint(catalog, candidate.id),
+                ...metadataMatchForEndpoint(metadata, candidate.id),
                 candidate,
               }
               return {
@@ -798,23 +839,32 @@ window.__ModuleLoader__.load({
               }
             })
           const enriched = prepared.map(item => item.candidate)
-          setCandidates(enriched)
-          setSelected(new Set(enriched.map(model => model.id)))
-          setModelDrafts(Object.fromEntries(enriched.map(model => [model.id, { ...model }])))
-          setCatalogMatches(Object.fromEntries(prepared
+          const fetchedIds = new Set(enriched.map(model => model.id))
+          const preserved = editing
+            ? (candidates ?? [])
+              .filter(model => selectedBeforeFetch.has(model.id) && !fetchedIds.has(model.id))
+              .map(model => draftsBeforeFetch[model.id] ?? { ...model })
+            : []
+          const nextCandidates = [...enriched, ...preserved]
+          setCandidates(nextCandidates)
+          setSelected(new Set(nextCandidates
+            .filter(model => selectedBeforeFetch.has(model.id))
+            .map(model => model.id)))
+          setModelDrafts(Object.fromEntries(nextCandidates.map(model => [model.id, draftsBeforeFetch[model.id] ?? { ...model }])))
+          setMetadataMatches(Object.fromEntries(prepared
             .filter(item => item.match !== undefined)
             .map(item => [item.candidate.id, item.match])))
-          setCatalogSelections(Object.fromEntries(prepared
+          setMetadataSelections(Object.fromEntries(prepared
             .filter(item => item.match !== undefined)
             .map(item => [item.candidate.id, item.match.selection])))
-          if (catalog === undefined) {
-            setCatalogNotice(t('catalogUnavailable'))
+          if (metadata === undefined) {
+            setMetadataNotice(t('metadataUnavailable'))
           } else {
             const matched = prepared.filter(item => item.match.reason !== 'none').length
             const official = prepared.filter(item => item.match.reason === 'official').length
             const ambiguous = prepared.filter(item => item.match.reason === 'default').length
             const unmatched = prepared.length - matched
-            setCatalogNotice(t('catalogApplied', { matched, official, ambiguous, unmatched }))
+            setMetadataNotice(t('metadataApplied', { matched, official, ambiguous, unmatched }))
           }
         } catch (error) {
           setFailure(messageOf(error))
@@ -834,10 +884,10 @@ window.__ModuleLoader__.load({
         .filter(model => !current.has(model.id))
         .map(model => model.id)))
       const updateSelectedModel = (id, next) => setModelDrafts(current => ({ ...current, [id]: next }))
-      const chooseCatalogSelection = (id, selection) => {
-        const match = catalogMatches[id]
+      const chooseMetadataSelection = (id, selection) => {
+        const match = metadataMatches[id]
         if (match === undefined || match.candidate === undefined) return
-        const previousSelection = catalogSelections[id] ?? match.selection
+        const previousSelection = metadataSelections[id] ?? match.selection
         const previous = enrichDiscoveredModel(match.candidate, match, previousSelection)
         const nextModel = enrichDiscoveredModel(match.candidate, match, selection)
         const current = modelDrafts[id] ?? previous
@@ -847,28 +897,78 @@ window.__ModuleLoader__.load({
           if (nextModel[field] === undefined) delete next[field]
           else next[field] = nextModel[field]
         }
-        setCatalogSelections(currentSelections => ({ ...currentSelections, [id]: selection }))
+        setMetadataSelections(currentSelections => ({ ...currentSelections, [id]: selection }))
         setModelDrafts(currentDrafts => ({ ...currentDrafts, [id]: next }))
+      }
+      const settingsOps = () => {
+        if (!editing) return [{ op: 'set', path: ['providers', route], value: profile }]
+        const ops = []
+        if (endpoint.name !== (initial.name ?? '')) {
+          ops.push({ op: 'set', path: ['providers', route, 'displayName'], value: endpoint.name })
+        }
+        if (endpoint.api !== (initial.api ?? '')) {
+          ops.push({ op: 'set', path: ['providers', route, 'api'], value: endpoint.api })
+        }
+        if (endpoint.baseURL.trim() !== (initial.baseURL ?? '')) {
+          ops.push({ op: 'set', path: ['providers', route, 'baseURL'], value: endpoint.baseURL.trim() })
+        }
+        if (modelsChanged) {
+          ops.push({ op: 'set', path: ['providers', route, 'models'], value: profile.models })
+        }
+        if (headersChanged) {
+          ops.push(Object.keys(effectiveHeaders).length === 0
+            ? { op: 'unset', path: ['providers', route, 'headers'] }
+            : { op: 'set', path: ['providers', route, 'headers'], value: effectiveHeaders })
+        }
+        if (initial.apiKeyEnv === undefined && keyChanged) {
+          ops.push({ op: 'set', path: ['providers', route, 'apiKeyEnv'], value: keyRef })
+        }
+        return ops
       }
       const save = async () => {
         setBusy(true)
         setFailure(undefined)
         try {
-          if (!profileCreated) {
-            const created = await api.settings.mutate({
-              ns: 'llm-pi-ai',
-              ops: [{ op: 'set', path: ['providers', route], value: profile }],
-              expectedRevision: namespace.revision,
-            })
-            if (!created.result.ok) {
-              setFailure(created.result.error.message)
+          if (!settingsSaved) {
+            const ops = settingsOps()
+            if (ops.length > 0) {
+              const created = await api.settings.mutate({
+                ns: 'llm-pi-ai',
+                ops,
+                expectedRevision: namespace.revision,
+              })
+              if (!created.result.ok) {
+                setFailure(created.result.error.message)
+                return
+              }
+            }
+            setSettingsSaved(true)
+          }
+          if (!editing || keyChanged) {
+            const stored = await api.credentials.set({ ref: keyRef, value: endpoint.apiKey.trim() })
+            if (!stored.result.ok) {
+              setFailure(stored.result.error.message)
               return
             }
-            setProfileCreated(true)
           }
-          const stored = await api.credentials.set({ ref: keyRef, value: endpoint.apiKey.trim() })
-          if (!stored.result.ok) {
-            setFailure(stored.result.error.message)
+          onSaved()
+        } catch (error) {
+          setFailure(messageOf(error))
+        } finally {
+          setBusy(false)
+        }
+      }
+      const restore = async () => {
+        setBusy(true)
+        setFailure(undefined)
+        try {
+          const response = await api.settings.mutate({
+            ns: 'llm-pi-ai',
+            ops: [{ op: 'unset', path: ['providers', route, 'models'] }],
+            expectedRevision: namespace.revision,
+          })
+          if (!response.result.ok) {
+            setFailure(response.result.error.message)
             return
           }
           onSaved()
@@ -880,22 +980,22 @@ window.__ModuleLoader__.load({
       }
       return h('div', { style: cardStyle },
         h('div', null,
-          h('h3', { style: { margin: 0, fontSize: '14px' } }, t('endpointTitle')),
+          h('h3', { style: { margin: 0, fontSize: '14px' } }, t(editing ? 'editEndpoint' : 'endpointTitle')),
           h('p', { style: { margin: '4px 0 0', color: 'var(--dsw-alias-label-tertiary)', fontSize: '13px' } }, t('endpointDescription')),
         ),
         h(Field, { label: t('endpointName') }, h('input', {
-          style: inputStyle, value: endpoint.name, disabled: busy || profileCreated,
+          style: inputStyle, value: endpoint.name, disabled: busy || settingsSaved,
           placeholder: t('endpointNamePlaceholder'), onChange: event => update('name', event.target.value),
         })),
         nameError !== undefined ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-error-primary)', fontSize: '12px' } }, nameError) : null,
         nameError === undefined ? h('p', { style: { margin: 0, color: routeTaken ? 'var(--dsw-alias-state-error-primary)' : 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, routeTaken ? t('routeTaken', { route }) : t('routePreview', { route, ref: keyRef })) : null,
         h(Field, { label: t('endpointUrl') }, h('input', {
-          style: inputStyle, type: 'url', value: endpoint.baseURL, disabled: busy || profileCreated,
+          style: inputStyle, type: 'url', value: endpoint.baseURL, disabled: busy || settingsSaved,
           placeholder: 'https://gateway.example/v1', onChange: event => update('baseURL', event.target.value),
         })),
         urlError !== undefined && endpoint.baseURL.length > 0 ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-error-primary)', fontSize: '12px' } }, urlError) : null,
         h(Field, { label: t('apiProtocol') }, h('select', {
-          style: inputStyle, value: endpoint.api, disabled: busy || profileCreated,
+          style: inputStyle, value: endpoint.api, disabled: busy || settingsSaved,
           onChange: event => update('api', event.target.value),
         },
         h('option', { value: 'openai-completions' }, 'openai-completions'),
@@ -905,38 +1005,51 @@ window.__ModuleLoader__.load({
         h(HeaderEditor, {
           value: endpoint.headers,
           onChange: headers => update('headers', headers),
-          disabled: busy || profileCreated,
+          disabled: busy || settingsSaved,
           error: requestHeadersError,
           t,
         }),
+        inheritedHeaders.length === 0 ? null : h(HeaderEditor, {
+          value: inheritedHeaders,
+          onChange: () => {},
+          disabled: true,
+          error: undefined,
+          t,
+          title: 'inheritedHeaders',
+          description: 'inheritedHeadersDescription',
+          addable: false,
+          removable: false,
+        }),
         h(Field, { label: t('endpointKey') }, h('input', {
           style: inputStyle, type: 'password', autoComplete: 'off', value: endpoint.apiKey, disabled: busy,
-          placeholder: t('endpointKeyPlaceholder'), onChange: event => {
-            if (profileCreated) setEndpoint(current => ({ ...current, apiKey: event.target.value }))
-            else update('apiKey', event.target.value)
-          },
+          placeholder: t(editing ? 'endpointKeyExistingPlaceholder' : 'endpointKeyPlaceholder'),
+          onChange: event => update('apiKey', event.target.value),
         })),
         keyError !== undefined ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-error-primary)', fontSize: '12px' } }, keyError) : null,
         h('div', { style: { display: 'flex', justifyContent: 'flex-end', gap: '8px' } },
-          h('button', { type: 'button', style: buttonStyle, disabled: busy || !readyToFetch || profileCreated, onClick: () => { void fetchModels() } }, busy ? t('fetching') : t('fetchModels')),
+          h('button', {
+            type: 'button', style: buttonStyle, disabled: busy || !readyToFetch || settingsSaved,
+            onClick: () => { void fetchModels() },
+          }, busy ? t(editing ? 'refreshingModels' : 'fetching') : t(editing ? 'refreshModels' : 'fetchModels')),
         ),
         candidates === undefined ? null : h('div', { style: { display: 'flex', flexDirection: 'column', gap: '8px' } },
           h('div', { style: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px', flexWrap: 'wrap' } },
             h('strong', { style: { fontSize: '13px' } }, t('chooseModels')),
             h('div', { style: { display: 'flex', gap: '6px' } },
-              h('button', { type: 'button', style: buttonStyle, disabled: busy || profileCreated, onClick: selectAll }, t('selectAll')),
-              h('button', { type: 'button', style: buttonStyle, disabled: busy || profileCreated, onClick: invertSelection }, t('invertSelection')),
-              h('button', { type: 'button', style: buttonStyle, disabled: busy || profileCreated, onClick: selectNone }, t('selectNone')),
+              h('button', { type: 'button', style: buttonStyle, disabled: busy || settingsSaved, onClick: selectAll }, t('selectAll')),
+              h('button', { type: 'button', style: buttonStyle, disabled: busy || settingsSaved, onClick: invertSelection }, t('invertSelection')),
+              h('button', { type: 'button', style: buttonStyle, disabled: busy || settingsSaved, onClick: selectNone }, t('selectNone')),
+              canRestoreInheritance ? h('button', { type: 'button', style: buttonStyle, disabled: busy || settingsSaved, onClick: () => { void restore() } }, t('restoreInheritance')) : null,
             ),
           ),
           h('div', { style: { display: 'flex', flexDirection: 'column', gap: '5px', maxHeight: '220px', overflow: 'auto' } }, candidates.map(model => h('label', { key: model.id, style: { display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px' } },
-            h('input', { type: 'checkbox', checked: selected.has(model.id), disabled: busy || profileCreated, onChange: () => toggle(model.id) }),
+            h('input', { type: 'checkbox', checked: selected.has(model.id), disabled: busy || settingsSaved, onChange: () => toggle(model.id) }),
             h('span', null, model.id),
           ))),
           selectedModels.length === 0 ? null : h('div', { style: { display: 'flex', flexDirection: 'column', gap: '8px' } },
             h('strong', { style: { fontSize: '13px' } }, t('selectedModelParameters')),
             selectedModels.map((model, index) => {
-              const match = catalogMatches[model.id]
+              const match = metadataMatches[model.id]
               const defaultProvider = match?.reason === 'default'
                 ? match.candidates.find(candidate => providerSelection(candidate.providerId) === match.selection)?.providerId
                 : undefined
@@ -946,13 +1059,13 @@ window.__ModuleLoader__.load({
                 model,
                 index,
                 onChange: next => updateSelectedModel(model.id, next),
-                disabled: busy || profileCreated,
+                disabled: busy || settingsSaved,
                 lockId: true,
-                catalogChoice: catalogSelections[model.id] ?? match?.selection,
-                catalogCandidates: match?.candidates,
-                catalogDefaultProvider: defaultProvider,
-                catalogOfficialProvider: officialProvider,
-                onCatalogChoice: next => chooseCatalogSelection(model.id, next),
+                metadataChoice: metadataSelections[model.id] ?? match?.selection,
+                metadataCandidates: match?.candidates,
+                metadataDefaultProvider: defaultProvider,
+                metadataOfficialProvider: officialProvider,
+                onMetadataChoice: next => chooseMetadataSelection(model.id, next),
                 t,
               })
             }),
@@ -964,15 +1077,16 @@ window.__ModuleLoader__.load({
           h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, t('keyPreviewNotice')),
         ),
         failure !== undefined ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-error-primary)', fontSize: '13px' } }, failure) : null,
-        catalogNotice === undefined ? null : h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, catalogNotice),
+          metadataNotice === undefined ? null : h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '12px' } }, metadataNotice),
         h('div', { style: { display: 'flex', justifyContent: 'flex-end', gap: '8px' } },
-          h('button', { type: 'button', style: buttonStyle, disabled: busy || profileCreated, onClick: onCancel }, t('cancel')),
+          h('button', { type: 'button', style: buttonStyle, disabled: busy, onClick: onCancel }, t('cancel')),
           h('button', {
             type: 'button',
             style: { ...buttonStyle, background: 'var(--dsw-alias-button-primary-fill)', color: 'var(--dsw-alias-label-primary-foreground)', borderColor: 'transparent' },
-            disabled: busy || !writable || !readyToFetch || selectedModels.length === 0,
+            disabled: busy || !writable || !readyToSave || selectedModels.length === 0
+              || (editing && !endpointChanged && !keyChanged),
             onClick: () => { void save() },
-          }, busy ? t('saving') : profileCreated ? t('retryKey') : t('confirmSave')),
+          }, busy ? t('saving') : settingsSaved ? t('retryKey') : editing ? t('saveChanges') : t('confirmSave')),
         ),
       )
     }
@@ -981,11 +1095,6 @@ window.__ModuleLoader__.load({
       const refresh = useSyncExternalStore(controller.subscribe, controller.getSnapshot, controller.getSnapshot)
       const [state, setState] = useState({ status: 'loading' })
       const [provider, setProvider] = useState('')
-      const [draft, setDraft] = useState([])
-      const [headerDraft, setHeaderDraft] = useState([])
-      const [draftRevision, setDraftRevision] = useState(-1)
-      const [saving, setSaving] = useState(false)
-      const [notice, setNotice] = useState(undefined)
       const [showCreate, setShowCreate] = useState(false)
 
       useEffect(() => {
@@ -1005,30 +1114,10 @@ window.__ModuleLoader__.load({
         return () => { alive = false }
       }, [api, refresh])
 
-      const namespace = state.status === 'ready' ? state.namespace : undefined
-      const profiles = namespace === undefined ? undefined : objectAt(namespace.value, ['providers'])
-      const providers = profiles !== null && typeof profiles === 'object' && !Array.isArray(profiles) ? Object.keys(profiles) : []
-      const activeProvider = providers.includes(provider) ? provider : providers[0]
-      const profile = activeProvider === undefined ? undefined : profiles[activeProvider]
-      const effectiveModels = profile !== null && typeof profile === 'object' && Array.isArray(profile.models) ? profile.models.map(copyModel) : []
-      const userProfile = activeProvider === undefined ? undefined : objectAt(namespace?.user, ['providers', activeProvider])
-      const baseProfile = activeProvider === undefined ? undefined : objectAt(namespace?.base, ['providers', activeProvider])
-      const userHeaders = userProfile !== null && typeof userProfile === 'object' ? headerRows(userProfile.headers) : []
-      const baseHeaders = baseProfile !== null && typeof baseProfile === 'object' ? headerRows(baseProfile.headers) : []
-      const namespaceRevision = namespace?.revision
-
-      useEffect(() => {
-        if (activeProvider === undefined || namespaceRevision === undefined) return
-        if (provider === activeProvider && draftRevision === namespaceRevision) return
-        setProvider(activeProvider)
-        setDraft(effectiveModels)
-        setHeaderDraft(userHeaders)
-        setDraftRevision(namespaceRevision)
-        setNotice(undefined)
-      }, [activeProvider, draftRevision, effectiveModels, namespaceRevision, provider, userHeaders])
-
       if (state.status === 'loading') return h('p', null, t('loading'))
       if (state.status === 'error') return h('p', { style: { color: 'var(--dsw-alias-state-error-primary)' } }, state.message)
+
+      const namespace = state.namespace
       if (namespace === undefined) {
         return h('section', { style: sectionStyle },
           h('h2', { style: { margin: 0, fontSize: '16px' } }, t('title')),
@@ -1036,168 +1125,73 @@ window.__ModuleLoader__.load({
         )
       }
 
-      const userModels = userProfile !== null && typeof userProfile === 'object' ? userProfile.models : undefined
-      const overridden = Array.isArray(userModels)
-      const canRestoreInheritance = overridden && baseProfile !== null && typeof baseProfile === 'object'
-      const models = provider === activeProvider && draftRevision === namespace.revision ? draft : effectiveModels
-      const requestHeaders = provider === activeProvider && draftRevision === namespace.revision ? headerDraft : userHeaders
-      const modelsChanged = provider === activeProvider && draftRevision === namespace.revision
-        && !jsonEqual(draft, effectiveModels)
-      const headersChanged = provider === activeProvider && draftRevision === namespace.revision
-        && !headersEqual(headersObject(headerDraft, baseHeaders), headersObject(userHeaders, baseHeaders))
-
+      const profiles = objectAt(namespace.value, ['providers'])
+      const providers = profiles !== null && typeof profiles === 'object' && !Array.isArray(profiles) ? Object.keys(profiles) : []
+      const activeProvider = providers.includes(provider) ? provider : providers[0]
+      const profile = activeProvider === undefined ? undefined : profiles[activeProvider]
+      const userProfile = activeProvider === undefined ? undefined : objectAt(namespace.user, ['providers', activeProvider])
+      const baseProfile = activeProvider === undefined ? undefined : objectAt(namespace.base, ['providers', activeProvider])
+      const canRestoreInheritance = activeProvider !== undefined
+        && userProfile !== null && typeof userProfile === 'object' && Array.isArray(userProfile.models)
+        && baseProfile !== null && typeof baseProfile === 'object'
+      const initial = activeProvider === undefined || profile === null || typeof profile !== 'object' ? undefined : {
+        name: typeof profile.displayName === 'string' ? profile.displayName : activeProvider,
+        baseURL: typeof profile.baseURL === 'string' ? profile.baseURL : '',
+        api: typeof profile.api === 'string' ? profile.api : 'openai-completions',
+        apiKeyEnv: typeof profile.apiKeyEnv === 'string' ? profile.apiKeyEnv : undefined,
+        models: Array.isArray(profile.models) ? profile.models : [],
+        headers: userProfile !== null && typeof userProfile === 'object' ? headerRows(userProfile.headers) : [],
+        inheritedHeaders: baseProfile !== null && typeof baseProfile === 'object' ? headerRows(baseProfile.headers) : [],
+      }
+      const emptyInitial = { name: '', baseURL: '', api: 'openai-completions', models: [], headers: [], inheritedHeaders: [] }
       const selectProvider = next => {
-        const nextProfile = profiles[next]
         setProvider(next)
-        setDraft(nextProfile !== null && typeof nextProfile === 'object' && Array.isArray(nextProfile.models)
-          ? nextProfile.models.map(copyModel)
-          : [])
-        const nextUserProfile = objectAt(namespace.user, ['providers', next])
-        setHeaderDraft(nextUserProfile !== null && typeof nextUserProfile === 'object' ? headerRows(nextUserProfile.headers) : [])
-        setDraftRevision(namespace.revision)
-        setNotice(undefined)
+        setShowCreate(false)
       }
-
-      const updateModel = (index, next) => setDraft(current => current.map((model, at) => at === index ? next : model))
-      const save = async () => {
-        if (!modelsChanged && !headersChanged) return
-        if (draftRevision !== namespace.revision) {
-          setNotice({ error: t('draftReloading') })
-          return
-        }
-        const error = modelsError(draft, t)
-        if (error !== undefined) {
-          setNotice({ error })
-          return
-        }
-        const requestHeadersError = headersError(headerDraft, t)
-        if (requestHeadersError !== undefined) {
-          setNotice({ error: requestHeadersError })
-          return
-        }
-        setSaving(true)
-        setNotice(undefined)
-        try {
-          const ops = modelsChanged
-            ? [{ op: 'set', path: ['providers', activeProvider, 'models'], value: draft }]
-            : []
-          if (headersChanged) {
-            const nextHeaders = headersObject(headerDraft, baseHeaders)
-            ops.push(Object.keys(nextHeaders).length === 0
-              ? { op: 'unset', path: ['providers', activeProvider, 'headers'] }
-              : { op: 'set', path: ['providers', activeProvider, 'headers'], value: nextHeaders })
-          }
-          const response = await api.settings.mutate({
-            ns: 'llm-pi-ai',
-            ops,
-            expectedRevision: namespace.revision,
-          })
-          if (!response.result.ok) {
-            setNotice({ error: response.result.error.message })
-            if (response.result.error.code === 'settings-conflict') controller.refresh()
-            return
-          }
-          setNotice({ success: t('saved') })
-          controller.refresh()
-        } catch (error) {
-          setNotice({ error: messageOf(error) })
-        } finally {
-          setSaving(false)
-        }
-      }
-      const reset = async () => {
-        setSaving(true)
-        setNotice(undefined)
-        try {
-          const response = await api.settings.mutate({
-            ns: 'llm-pi-ai',
-            ops: [{ op: 'unset', path: ['providers', activeProvider, 'models'] }],
-            expectedRevision: namespace.revision,
-          })
-          if (!response.result.ok) {
-            setNotice({ error: response.result.error.message })
-            return
-          }
-          setNotice({ success: t('restored') })
-          controller.refresh()
-        } catch (error) {
-          setNotice({ error: messageOf(error) })
-        } finally {
-          setSaving(false)
-        }
-      }
-      const discard = () => {
-        setDraft(effectiveModels)
-        setHeaderDraft(userHeaders)
-        setDraftRevision(namespace.revision)
-        setNotice(undefined)
+      const openCreate = () => {
+        setShowCreate(true)
+        setProvider('')
       }
 
       return h('section', { style: sectionStyle },
         h('div', null,
           h('h2', { style: { margin: 0, fontSize: '16px', lineHeight: '24px' } }, t('title')),
-          h('p', { style: { margin: '4px 0 0', color: 'var(--dsw-alias-label-tertiary)', fontSize: '14px', lineHeight: '22px' } },
-            t('intro'),
-          ),
+          h('p', { style: { margin: '4px 0 0', color: 'var(--dsw-alias-label-tertiary)', fontSize: '14px', lineHeight: '22px' } }, t('intro')),
         ),
-        providers.length === 0 ? h('p', { style: cardStyle }, t('noProviders')) : h('div', { style: cardStyle },
-          h(Field, { label: t('provider') }, h('select', {
-            style: inputStyle, value: activeProvider, disabled: saving,
+        h('div', { style: { display: 'flex', alignItems: 'flex-end', gap: '8px' } },
+          providers.length === 0 ? null : h(Field, { label: t('provider') }, h('select', {
+            style: inputStyle, value: activeProvider, disabled: showCreate,
             onChange: event => selectProvider(event.target.value),
           }, providers.map(id => h('option', { key: id, value: id }, id)))),
-          baseHeaders.length === 0 ? null : h(HeaderEditor, {
-            value: baseHeaders,
-            onChange: () => {},
-            disabled: true,
-            error: undefined,
-            t,
-            title: 'inheritedHeaders',
-            description: 'inheritedHeadersDescription',
-            addable: false,
-            removable: false,
-          }),
-          h(HeaderEditor, {
-            value: requestHeaders,
-            onChange: setHeaderDraft,
-            disabled: saving || !state.writable,
-            error: headersError(headerDraft, t),
-            t,
-          }),
-          h('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px' } },
-            h('span', { style: { fontSize: '12px', color: 'var(--dsw-alias-label-tertiary)' } }, overridden ? t('inheritedModels') : t('materializedModels')),
-            canRestoreInheritance ? h('button', { type: 'button', style: buttonStyle, disabled: saving || !state.writable, onClick: reset }, t('restoreInheritance')) : null,
-          ),
-          models.length === 0 ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-label-tertiary)', fontSize: '13px' } }, t('noModels')) : h('div', { style: { display: 'flex', flexDirection: 'column', gap: '8px' } },
-            models.map((model, index) => h(ModelRow, {
-              key: `${model.id || 'model'}-${index}`, model, index,
-              onChange: next => updateModel(index, next), disabled: saving || !state.writable, t,
-            })),
-          ),
-          notice?.error !== undefined ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-error-primary)', fontSize: '13px' } }, notice.error) : null,
-          notice?.success !== undefined ? h('p', { style: { margin: 0, color: 'var(--dsw-alias-state-success-primary)', fontSize: '13px' } }, notice.success) : null,
-          h('div', { style: { display: 'flex', justifyContent: 'flex-end', gap: '8px' } },
-            h('button', { type: 'button', style: buttonStyle, disabled: saving, onClick: discard }, t('discardReload')),
-            h('button', {
-              type: 'button',
-              style: { ...buttonStyle, background: 'var(--dsw-alias-button-primary-fill)', color: 'var(--dsw-alias-label-primary-foreground)', borderColor: 'transparent' },
-              disabled: saving || !state.writable || (!modelsChanged && !headersChanged)
-                || (modelsChanged && models.length === 0) || headersError(headerDraft, t) !== undefined,
-              onClick: () => { void save() },
-            }, saving ? t('saving') : t('save')),
-          ),
+          h('button', { type: 'button', style: buttonStyle, disabled: !state.writable || showCreate, onClick: openCreate }, t('addEndpoint')),
         ),
-        showCreate ? h(NewEndpointCard, {
+        showCreate ? h(EndpointEditor, {
+          key: 'new-endpoint',
           api,
           namespace,
+          initial: emptyInitial,
           taken: providers,
           writable: state.writable,
+          canRestoreInheritance: false,
           t,
           onCancel: () => setShowCreate(false),
           onSaved: () => {
             setShowCreate(false)
             controller.refresh()
           },
-        }) : h('button', { type: 'button', style: buttonStyle, disabled: saving || !state.writable, onClick: () => setShowCreate(true) }, t('addEndpoint')),
+        }) : activeProvider === undefined ? h('p', { style: cardStyle }, t('noProviders')) : h(EndpointEditor, {
+          key: `${activeProvider}-${namespace.revision}`,
+          api,
+          namespace,
+          provider: activeProvider,
+          initial,
+          taken: providers,
+          writable: state.writable,
+          canRestoreInheritance,
+          t,
+          onCancel: () => controller.refresh(),
+          onSaved: () => controller.refresh(),
+        }),
       )
     }
 


### PR DESCRIPTION
Related to #2

## Summary

This change makes the saved-provider editor and the new-endpoint flow use the same endpoint editor. It also replaces the remaining Chinese “目录” terminology with “模型列表” or “模型元数据” where appropriate.

## Changes

- Reuse one `EndpointEditor` for new and saved providers.
- Allow saved providers to edit display name, endpoint URL, protocol, headers, models, and credentials.
- Add model refresh for saved providers using the stored provider credential when no replacement key is entered.
- Keep currently selected models checked after refresh; leave newly discovered models unchecked. Preserve selected models missing from a refreshed endpoint to avoid accidental removal.
- Keep provider routes stable while allowing display names to change.
- Preserve inherited headers and the restore-inheritance model action.
- Update only changed fields for existing providers with revision checks; keep unrelated provider settings intact.
- Keep new endpoint names alphanumeric after an initial English letter.
- Rename client metadata state and helper identifiers from `catalog*` to `metadata*`; update UI and design documentation terminology.

## Documentation

- Document the shared endpoint editor, edit mode, refresh behavior, selection defaults, credential handling, restore inheritance, and save operations.
- Clarify the distinction between endpoint model lists and `models.dev` model metadata.

## Validation

- `node --check src/client.js`
- `git diff --check`

No additional test suite was run for this client-only bundle.