### PR TITLE
fix: align docs and omit empty advanced params

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,22 @@ Adds an Advanced Model Configuration page to the [DeepSeek Harness](https://gith
 
 See the [llm-pi-ai parameter reference](docs/llm-pi-ai-parameters.md) for the complete configuration table.
 
-Custom headers apply only to model requests. **Fetch available models** still uses the API key.
+**Open settings**
+<img width="1666" height="810" alt="image" src="https://github.com/user-attachments/assets/945e6566-dca2-45ca-bcc3-4609ea47f079" />
+
+**Add an endpoint**
+Enter the endpoint name, BASE_URL, and API key, then fetch models and check the ones you want:
+<img width="1746" height="1580" alt="image" src="https://github.com/user-attachments/assets/828f36ea-8a7d-4021-9dbb-253d60a1e949" />
+
+**Fill in remaining parameters**
+1. Endpoint advanced parameters: the defaults are usually fine. Custom headers apply only to model requests; **Fetch available models** still uses the API key.
+
+<img width="1712" height="1613" alt="image" src="https://github.com/user-attachments/assets/e185563c-4b89-468f-8463-49463c5b6e41" />
+
+2. Model parameters: mainly check the context window and maximum output length.
+<img width="1744" height="1628" alt="image" src="https://github.com/user-attachments/assets/a9a1e123-1e78-4435-addc-02ded574ba83" />
+
+Model parameters are usually filled in automatically, as long as [https://models.dev](https://models.dev) is reachable.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@
 <img width="1746" height="1580" alt="image" src="https://github.com/user-attachments/assets/828f36ea-8a7d-4021-9dbb-253d60a1e949" />
 
 **参数补充**
-1. 端点高级参数：一般保持默认即可。
+1. 端点高级参数：一般保持默认即可。自定义 Header 仅用于模型请求；“获取可用模型”仍使用 API Key。
 
 <img width="1712" height="1613" alt="image" src="https://github.com/user-attachments/assets/e185563c-4b89-468f-8463-49463c5b6e41" />
 
-3. 模型参数：主要检查上下文大小和最大输出长度。
+2. 模型参数：主要检查上下文大小和最大输出长度。
 <img width="1744" height="1628" alt="image" src="https://github.com/user-attachments/assets/a9a1e123-1e78-4435-addc-02ded574ba83" />
 
-模型参数一般能自动填写，前提时要能访问 [https://models.dev](https://models.dev)
+模型参数一般能自动填写，前提是要能访问 [https://models.dev](https://models.dev)
 
 ## 安装
 

--- a/docs/llm-pi-ai-parameters.md
+++ b/docs/llm-pi-ai-parameters.md
@@ -230,9 +230,9 @@ retryPolicy:
 
 | 场景 | 行为 |
 |---|---|
-| 新增端点高级参数为空 | 不写入 profile，使用 adapter/schema 默认行为。 |
+| 新增端点高级参数为空 | 不写入 profile，使用 adapter/schema 默认行为。空数组和空对象也视为空。 |
 | 编辑端点时不修改参数 | 不生成对应 settings op。 |
-| 编辑端点后清空参数 | 对应字段使用 `unset`，恢复 base 或 schema 默认值。 |
+| 编辑端点后清空参数 | 对应字段使用 `unset`，恢复 base 或 schema 默认值。空数组和空对象也视为清空。 |
 | 显式配置模型 `maxTokens` | 既声明模型能力，也成为请求默认输出上限。 |
 | 只继承 catalog 的 `maxTokens` | 只作为模型能力，不自动成为请求默认值。 |
 | `models` 非空 | 替换 route 的完整模型列表。 |

--- a/docs/model-config-plugin-design.md
+++ b/docs/model-config-plugin-design.md
@@ -142,7 +142,7 @@ models:
 - **恢复继承**：已存在用户层 `models` 覆盖且存在 base 模型列表时，编辑器保留“恢复继承”动作，显式执行 `unset providers.<route>.models`，恢复 base 层模型列表。
 - **删除端点**：已保存端点在端点选择栏旁提供删除动作，确认后以 `unset providers.<route>` 删除用户层配置；只有 `apiKeyEnv` 等于插件按 route 派生的 `<ROUTE>_API_KEY` 时才同步删除凭据，用户自定义凭据引用不会被自动删除。
 - **端点高级参数**：编辑器暴露自定义/继承 Header、`defaultContextWindow`、`defaultMaxTokens`、`defaultInput`、默认 `reasoning`、`thinkingBudgets`、`compat`、`cacheRetention`、`transport`、`timeoutMs`、`websocketConnectTimeoutMs`、`streamIdleTimeoutMs` 和 `retryPolicy`；字段默认为空，空值不写入最终 profile，已存在的用户层值重置后使用 `unset`。
-- **保存**：新增模式写入整段 profile；编辑模式只写入发生变化的 displayName、api、baseURL、models、headers 和必要的 apiKeyEnv 字段，并携带 `expectedRevision`。只有保存成功后才调用 `onSaved` 刷新设置快照。
+- **保存**：新增模式写入整段 profile；编辑模式只写入发生变化的 displayName、api、baseURL、models、headers、端点高级参数和必要的 apiKeyEnv 字段，并携带 `expectedRevision`。空数组和空对象与空值相同，新增时不写入，编辑时 `unset`。只有保存成功后才调用 `onSaved` 刷新设置快照。
 - **布局**：顶部选择已保存端点或进入“新增端点”；两种模式下端点字段、重新拉取、模型选择、参数编辑、配置预览和保存按钮位置一致。模型列表加载后，即使没有勾选模型或端点高级参数折叠，配置预览仍实时显示端点高级参数。
 
 ### 5.3 拉取模型

--- a/src/client.js
+++ b/src/client.js
@@ -19,15 +19,15 @@ window.__ModuleLoader__.load({
       nav: 'Advanced model config',
       title: 'Advanced model config',
       loading: 'Loading model configuration…',
-      adapterMissing: 'llm-pi-ai is not loaded. Add a custom provider from the Models page first.',
-      intro: 'Declare capacities and reasoning support for custom models. Endpoints, keys, and model discovery remain on the Models page.',
+      adapterMissing: 'llm-pi-ai is not loaded. Enable the llm-pi-ai adapter first.',
+      intro: 'Create custom endpoints and declare each model\'s capacity and reasoning support.',
       parameterReference: 'Parameter reference',
-      noProviders: 'No custom provider yet. Add a provider and at least one model from the Models page.',
+      noProviders: 'No custom provider yet. Add an endpoint here, then fetch and select at least one model.',
       provider: 'Provider',
       inheritedModels: 'Editing the user-layer model list',
       materializedModels: 'Editing materializes the model list in the user layer',
       restoreInheritance: 'Restore inheritance',
-      noModels: 'This provider has no editable models. Add or fetch models from the Models page.',
+      noModels: 'This provider has no editable models. Fetch models from this page, then select at least one.',
       discardReload: 'Discard and reload',
       save: 'Save',
       saving: 'Saving…',
@@ -153,15 +153,15 @@ window.__ModuleLoader__.load({
       nav: '模型高级配置',
       title: '模型高级配置',
       loading: '正在加载模型配置…',
-      adapterMissing: '未装载 llm-pi-ai。请先在“模型”页添加一个自定义提供方。',
-      intro: '在此声明自定义模型的容量与推理能力。端点、密钥和获取可用模型仍在“模型”页管理。',
+      adapterMissing: '未装载 llm-pi-ai。请先启用 llm-pi-ai 适配器。',
+      intro: '在此新增自定义端点，并声明每个模型的容量与推理能力。',
       parameterReference: '参数文档',
-      noProviders: '尚无自定义提供方。请先在“模型”页添加一个提供方和至少一个模型。',
+      noProviders: '尚无自定义提供方。请在本页新增端点，然后获取并勾选至少一个模型。',
       provider: '提供方',
       inheritedModels: '正在编辑用户层模型列表',
       materializedModels: '编辑后会在用户层物化模型列表',
       restoreInheritance: '恢复继承',
-      noModels: '该提供方没有可编辑的模型。请在“模型”页添加或获取模型。',
+      noModels: '该提供方没有可编辑的模型。请在本页获取模型，然后勾选至少一个。',
       discardReload: '放弃并重新加载',
       save: '保存',
       saving: '保存中…',
@@ -554,6 +554,20 @@ window.__ModuleLoader__.load({
 
     function jsonEqual(left, right) {
       return JSON.stringify(left) === JSON.stringify(right)
+    }
+
+    function presentAdvancedValue(value) {
+      if (value === undefined) return false
+      if (Array.isArray(value)) return value.length > 0
+      if (value !== null && typeof value === 'object') return Object.keys(value).length > 0
+      return true
+    }
+
+    function normalizeAdvanced(value) {
+      const source = value !== null && typeof value === 'object' ? value : {}
+      return Object.fromEntries(PROVIDER_ADVANCED_FIELDS
+        .filter(field => presentAdvancedValue(source[field]))
+        .map(field => [field, source[field]]))
     }
 
     function copyModel(model) {
@@ -1109,14 +1123,9 @@ window.__ModuleLoader__.load({
       const endpointChanged = !editing || endpoint.name !== (initial.name ?? '')
         || endpoint.baseURL.trim() !== (initial.baseURL ?? '')
         || endpoint.api !== (initial.api ?? '') || modelsChanged || headersChanged
-        || !jsonEqual(advanced, initialAdvanced)
+        || !jsonEqual(normalizeAdvanced(advanced), normalizeAdvanced(initialAdvanced))
       const keyChanged = endpoint.apiKey.trim() !== ''
-      const advancedProfile = Object.fromEntries(Object.entries(advanced).filter(([, value]) => {
-        if (value === undefined) return false
-        if (Array.isArray(value)) return value.length > 0
-        if (value !== null && typeof value === 'object') return Object.keys(value).length > 0
-        return true
-      }))
+      const advancedProfile = normalizeAdvanced(advanced)
       const profile = {
         displayName: endpoint.name,
         apiKeyEnv: keyRef,
@@ -1265,10 +1274,12 @@ window.__ModuleLoader__.load({
               : { op: 'set', path: ['providers', route, 'headers'], value: effectiveHeaders })
         }
         for (const field of PROVIDER_ADVANCED_FIELDS) {
-          if (jsonEqual(advanced[field], initialAdvanced[field])) continue
-          ops.push(advanced[field] === undefined
+          const next = presentAdvancedValue(advanced[field]) ? advanced[field] : undefined
+          const previous = presentAdvancedValue(initialAdvanced[field]) ? initialAdvanced[field] : undefined
+          if (jsonEqual(next, previous)) continue
+          ops.push(next === undefined
             ? { op: 'unset', path: ['providers', route, field] }
-            : { op: 'set', path: ['providers', route, field], value: advanced[field] })
+            : { op: 'set', path: ['providers', route, field], value: next })
         }
         if (initial.apiKeyEnv === undefined && keyChanged) {
           ops.push({ op: 'set', path: ['providers', route, 'apiKeyEnv'], value: keyRef })


### PR DESCRIPTION
## Summary
- Sync the English README with the Chinese screenshot walkthrough and restore the custom-header note.
- Point page copy at this settings page instead of the Models page.
- Treat empty advanced arrays/objects as unset so edit-mode saves match create-mode.

## Test plan
- [ ] Confirm README.md and README.en.md show the same 1/2 walkthrough.
- [ ] Open Advanced model config with no providers and confirm the empty-state copy no longer mentions the Models page.
- [ ] Edit an endpoint, clear an advanced object/array, save, and confirm the field is unset rather than written as `{}` or `[]`.